### PR TITLE
Assert at build time that the target is little-endian.

### DIFF
--- a/atom.rs
+++ b/atom.rs
@@ -20,6 +20,13 @@ use sync::mutex::Mutex;
 use sync::one::{Once, ONCE_INIT};
 use std::rt::heap;
 
+
+// Inline atoms are probably buggy on big-endian architectures.
+#[allow(dead_code)]
+#[static_assert]
+static IS_LITTLE_ENDIAN: bool = cfg!(target_endian = "little");
+
+
 static mut global_string_cache_ptr: *mut StringCache = 0 as *mut StringCache;
 
 static STATIC_SHIFT_BITS: uint = 32;


### PR DESCRIPTION
I’m not sure, but I believe that the code for inline atoms is buggy on big-endian architectures. It seems like we don’t care enough about these architectures to make it worth fixing this, but in case someone ever tries, this should warn them.

r? @glennw
