### PR TITLE
Update to make FNV hashing work

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![crate_name = "string_cache"]
 #![crate_type = "rlib"]
 
-#![feature(phase, macro_rules)]
+#![feature(phase, macro_rules, default_type_params)]
 
 extern crate sync;
 extern crate debug;


### PR DESCRIPTION
To hash atoms with algorithms other than siphash, default_type_params
must be enabled. This is needed in servo for a fast bloom filter.
