### PR TITLE
Upgrade to rustc 0.13.0-nightly (222ae8b9b 2014-10-18 00:47:22 +0000)

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -45,7 +45,7 @@ static static_atom_set: PhfOrderedSet<&'static str> = static_atom_set!();
 // NOTE: Deriving Eq here implies that a given string must always
 // be interned the same way.
 #[repr(u8)]
-#[deriving(Eq, PartialEq)]
+#[deriving(Eq, PartialEq, Show)]
 enum AtomType {
     Dynamic = 0,
     Inline = 1,
@@ -300,7 +300,7 @@ impl Drop for Atom {
 
 impl fmt::Show for Atom {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Atom('{:s}' type={:?})", self.as_slice(), self.get_type())
+        write!(f, "Atom('{:s}' type={})", self.as_slice(), self.get_type())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@ extern crate core;
 extern crate alloc;
 extern crate collections;
 extern crate sync;
-extern crate debug;
 
 #[cfg(test)]
 extern crate test;


### PR DESCRIPTION
This pull request fixes breaking change in latest `rustc`. It removes `extern crate debug` and replaces all `{:?}` with `{}`, while adding Show to `AtomType`.
