### PR TITLE
Switch to using std::sync instead of libsync

### DIFF
--- a/macros/src/atom/mod.rs
+++ b/macros/src/atom/mod.rs
@@ -15,7 +15,6 @@ use syntax::ext::base::{ExtCtxt, MacResult, MacExpr};
 use syntax::parse::token::{get_ident, InternedString, Ident, Literal, Lit};
 
 use std::iter::Chain;
-use std::slice::{Items, Found, NotFound};
 use std::collections::HashMap;
 use std::ascii::AsciiExt;
 

--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -24,7 +24,7 @@ use alloc::heap;
 use alloc::boxed::Box;
 use collections::string::String;
 use collections::hash::{Hash, Hasher};
-use sync::Mutex;
+use std::sync::Mutex;
 
 use self::repr::{UnpackedAtom, Static, Inline, Dynamic};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,10 @@ extern crate core;
 
 extern crate alloc;
 extern crate collections;
-extern crate sync;
 
 #[cfg(test)]
 extern crate test;
 
-#[cfg(test)]
 extern crate std;
 
 #[phase(plugin)]
@@ -58,15 +56,4 @@ pub mod namespace;
 mod string_cache {
     pub use atom;
     pub use namespace;
-}
-
-// For macros and deriving.
-#[cfg(not(test))]
-mod std {
-    pub use core::{cmp, fmt, clone, option, mem, result};
-    pub use collections::hash;
-
-    pub mod sync {
-        pub use sync::one::{Once, ONCE_INIT};
-    }
 }


### PR DESCRIPTION
libsync has been removed from rust, which means that for sync primitives, std::sync is required. This switches string-cache to using std::sync. 

Unfortunately, this means that string-cache now depends on both std and core. A better patch which doesn't have this problem would probably be a good idea.
