### PR TITLE
Remove #![no-std] and dependency on libcore

### DIFF
--- a/macros/src/atom/mod.rs
+++ b/macros/src/atom/mod.rs
@@ -14,7 +14,6 @@ use syntax::ast;
 use syntax::ext::base::{ExtCtxt, MacResult, MacExpr};
 use syntax::parse::token::{get_ident, InternedString, Ident, Literal, Lit};
 
-use std::iter::Chain;
 use std::collections::HashMap;
 use std::ascii::AsciiExt;
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -13,7 +13,6 @@
 #![feature(macro_rules, plugin_registrar, quote, phase)]
 #![allow(unused_imports)]  // for quotes
 
-extern crate core;
 extern crate syntax;
 extern crate rustc;
 

--- a/shared/repr.rs
+++ b/shared/repr.rs
@@ -13,11 +13,8 @@
 
 #![allow(dead_code, unused_imports)]
 
-use core::{mem, raw, intrinsics};
-use core::option::{Option, Some, None};
-use core::ptr::RawPtr;
-use core::slice::{SlicePrelude, AsSlice};
-use core::slice::bytes;
+use std::{mem, raw, intrinsics};
+use std::slice::bytes;
 
 pub use self::UnpackedAtom::{Dynamic, Inline, Static};
 

--- a/src/atom/bench.rs
+++ b/src/atom/bench.rs
@@ -131,10 +131,7 @@ macro_rules! bench_all (
         mod $name {
             #![allow(unused_imports)]
 
-            use core::prelude::*;
-            use collections::vec::Vec;
             use test::{Bencher, black_box};
-            use std::string::ToString;
 
             use atom::Atom;
             use atom::repr::{Static, Inline, Dynamic};
@@ -189,7 +186,6 @@ macro_rules! bench_rand ( ($name:ident, $len:expr) => (
     #[bench]
     fn $name(b: &mut Bencher) {
         use std::{str, rand};
-        use std::slice::{SlicePrelude, AsSlice};
         use std::rand::Rng;
 
         let mut gen = rand::weak_rng();

--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -9,21 +9,14 @@
 
 #![allow(non_upper_case_globals)]
 
-use core::prelude::*;
-
 use phf::OrderedSet;
 use xxhash::XXHasher;
 
-use core::fmt;
-use core::mem;
-use core::ptr;
-use core::slice::bytes;
-use core::str;
-use core::atomic::{AtomicInt, SeqCst};
-use alloc::heap;
-use alloc::boxed::Box;
-use collections::string::String;
-use collections::hash::{Hash, Hasher};
+use std::{fmt, mem, ptr, str};
+use std::slice::bytes;
+use std::sync::atomic::{AtomicInt, SeqCst};
+use std::rt::heap;
+use std::hash::{Hash, Hasher};
 use std::sync::Mutex;
 
 use self::repr::{UnpackedAtom, Static, Inline, Dynamic};
@@ -292,8 +285,6 @@ mod bench;
 
 #[cfg(test)]
 mod tests {
-    use core::prelude::*;
-
     use std::fmt;
     use std::task::spawn;
     use super::Atom;
@@ -460,7 +451,7 @@ mod tests {
     #[test]
     fn assert_sizes() {
         // Guard against accidental changes to the sizes of things.
-        use core::mem;
+        use std::mem;
         assert_eq!(8, mem::size_of::<super::Atom>());
         assert_eq!(48, mem::size_of::<super::StringCacheEntry>());
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,13 +9,9 @@
 
 #![macro_escape]
 
-use core::prelude::*;
+use std::sync::Mutex;
 
-use alloc::boxed::Box;
-use collections::MutableSeq;
-use collections::vec::Vec;
-use collections::string::String;
-use sync::Mutex;
+pub use self::Event::{Intern, Insert, Remove};
 
 #[deriving(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Show, Encodable)]
 pub enum Event {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,18 +11,9 @@
 #![crate_type = "rlib"]
 
 #![feature(phase, macro_rules, default_type_params, globs)]
-#![no_std]
-
-#[phase(plugin, link)]
-extern crate core;
-
-extern crate alloc;
-extern crate collections;
 
 #[cfg(test)]
 extern crate test;
-
-extern crate std;
 
 #[phase(plugin)]
 extern crate phf_mac;

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -9,8 +9,6 @@
 
 #![experimental="This may move as string-cache becomes less Web-specific."]
 
-use core::prelude::*;
-
 use atom::Atom;
 
 /// An atom that is meant to represent a namespace in the HTML / XML sense.


### PR DESCRIPTION
As libsync was removed, string-cache now must depend on libstd. This removes string-cache's dependency on libcore, and switches to depending on libstd.

This would close #53