### PR TITLE
Update to build with latest rustc nightly

### DIFF
--- a/macros/src/atom/mod.rs
+++ b/macros/src/atom/mod.rs
@@ -139,4 +139,4 @@ macro_rules! qualname (($ns:tt, $local:tt) => (
         ns: ns!($ns),
         local: atom!($local),
     }
-))
+));

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,14 +10,14 @@
 #![crate_name="string_cache_macros"]
 #![crate_type="dylib"]
 
-#![feature(macro_rules, plugin_registrar, quote, phase)]
+#![feature(plugin_registrar, quote)]
 #![allow(unused_imports)]  // for quotes
 
 extern crate core;
 extern crate syntax;
 extern crate rustc;
 
-#[phase(plugin)]
+#[macro_use]
 extern crate lazy_static;
 
 use rustc::plugin::Registry;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -25,18 +25,18 @@ use rustc::plugin::Registry;
 macro_rules! bail ( ($cx:expr, $sp:expr, $msg:expr) => ({
     $cx.span_err($sp, $msg);
     return ::syntax::ext::base::DummyResult::any($sp);
-}))
+}));
 
 macro_rules! bail_if ( ($e:expr, $cx:expr, $sp:expr, $msg:expr) => (
     if $e { bail!($cx, $sp, $msg) }
-))
+));
 
 macro_rules! expect ( ($cx:expr, $sp:expr, $e:expr, $msg:expr) => (
     match $e {
         Some(x) => x,
         None => bail!($cx, $sp, $msg),
     }
-))
+));
 
 mod atom;
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,7 +10,7 @@
 #![crate_name="string_cache_macros"]
 #![crate_type="dylib"]
 
-#![feature(plugin_registrar, quote)]
+#![feature(plugin_registrar, quote, int_uint, box_syntax)]
 #![allow(unused_imports)]  // for quotes
 
 extern crate core;

--- a/shared/repr.rs
+++ b/shared/repr.rs
@@ -14,9 +14,9 @@
 #![allow(dead_code, unused_imports)]
 
 use core::{mem, raw, intrinsics};
-use core::option::{Option, Some, None};
-use core::ptr::RawPtr;
-use core::slice::{SlicePrelude, AsSlice};
+use core::option::Option::{self, Some, None};
+use core::ptr::PtrExt;
+use core::slice::{AsSlice, SliceExt};
 use core::slice::bytes;
 
 pub use self::UnpackedAtom::{Dynamic, Inline, Static};
@@ -35,7 +35,7 @@ pub enum UnpackedAtom {
     Dynamic(*mut ()),
 
     /// Length + bytes of string.
-    Inline(u8, [u8, ..7]),
+    Inline(u8, [u8; 7]),
 
     /// Index in static interning table.
     Static(u32),
@@ -91,7 +91,7 @@ impl UnpackedAtom {
             INLINE_TAG => {
                 let len = ((data & 0xf0) >> 4) as uint;
                 debug_assert!(len <= MAX_INLINE_LEN);
-                let mut buf: [u8, ..7] = [0, ..7];
+                let mut buf: [u8; 7] = [0; 7];
                 let src: &[u8] = mem::transmute(inline_atom_slice(&data));
                 bytes::copy_memory(buf.as_mut_slice(), src);
                 Inline(len as u8, buf)

--- a/shared/repr.rs
+++ b/shared/repr.rs
@@ -26,7 +26,7 @@ pub const DYNAMIC_TAG: u8 = 0u8;
 pub const INLINE_TAG: u8 = 1u8;  // len in upper nybble
 pub const STATIC_TAG: u8 = 2u8;
 
-pub const MAX_INLINE_LEN: uint = 7;
+pub const MAX_INLINE_LEN: usize = 7;
 
 // Atoms use a compact representation which fits this enum in a single u64.
 // Inlining avoids actually constructing the unpacked representation in memory.
@@ -41,7 +41,7 @@ pub enum UnpackedAtom {
     Static(u32),
 }
 
-const STATIC_SHIFT_BITS: uint = 32;
+const STATIC_SHIFT_BITS: usize = 32;
 
 #[inline(always)]
 unsafe fn inline_atom_slice(x: &u64) -> raw::Slice<u8> {
@@ -69,7 +69,7 @@ impl UnpackedAtom {
                 n
             }
             Inline(len, buf) => {
-                debug_assert!((len as uint) <= MAX_INLINE_LEN);
+                debug_assert!((len as usize) <= MAX_INLINE_LEN);
                 let mut data: u64 = (INLINE_TAG as u64) | ((len as u64) << 4);
                 {
                     let dest: &mut [u8] = mem::transmute(inline_atom_slice(&mut data));
@@ -89,7 +89,7 @@ impl UnpackedAtom {
             DYNAMIC_TAG => Dynamic(data as *mut ()),
             STATIC_TAG => Static((data >> STATIC_SHIFT_BITS) as u32),
             INLINE_TAG => {
-                let len = ((data & 0xf0) >> 4) as uint;
+                let len = ((data & 0xf0) >> 4) as usize;
                 debug_assert!(len <= MAX_INLINE_LEN);
                 let mut buf: [u8; 7] = [0; 7];
                 let src: &[u8] = mem::transmute(inline_atom_slice(&data));

--- a/src/atom/bench.rs
+++ b/src/atom/bench.rs
@@ -44,14 +44,14 @@ macro_rules! check_type (($name:ident, $x:expr, $p:pat) => (
             _ => panic!("atom has wrong type"),
         }
     }
-))
+));
 
 macro_rules! bench_tiny_op (($name:ident, $op:ident, $ctor_x:expr, $ctor_y:expr) => (
     #[bench]
     fn $name(b: &mut Bencher) {
         const n: uint = 1000;
-        let xs = Vec::from_elem(n, $ctor_x);
-        let ys = Vec::from_elem(n, $ctor_y);
+        let xs: Vec<_> = repeat($ctor_x).take(n).collect();
+        let ys: Vec<_> = repeat($ctor_y).take(n).collect();
 
         b.iter(|| {
             for (x, y) in xs.iter().zip(ys.iter()) {
@@ -59,22 +59,22 @@ macro_rules! bench_tiny_op (($name:ident, $op:ident, $ctor_x:expr, $ctor_y:expr)
             }
         });
     }
-))
+));
 
 macro_rules! bench_one (
-    (x_static   $x:expr, $y:expr) => (check_type!(check_type_x, $x, Static(..)));
-    (x_inline   $x:expr, $y:expr) => (check_type!(check_type_x, $x, Inline(..)));
-    (x_dynamic  $x:expr, $y:expr) => (check_type!(check_type_x, $x, Dynamic(..)));
-    (y_static   $x:expr, $y:expr) => (check_type!(check_type_y, $y, Static(..)));
-    (y_inline   $x:expr, $y:expr) => (check_type!(check_type_y, $y, Inline(..)));
-    (y_dynamic  $x:expr, $y:expr) => (check_type!(check_type_y, $y, Dynamic(..)));
-    (is_static  $x:expr, $y:expr) => (bench_one!(x_static  $x, $y) bench_one!(y_static  $x, $y));
-    (is_inline  $x:expr, $y:expr) => (bench_one!(x_inline  $x, $y) bench_one!(y_inline  $x, $y));
-    (is_dynamic $x:expr, $y:expr) => (bench_one!(x_dynamic $x, $y) bench_one!(y_dynamic $x, $y));
+    (x_static   $x:expr, $y:expr) => (check_type!(check_type_x, $x, Static(..)););
+    (x_inline   $x:expr, $y:expr) => (check_type!(check_type_x, $x, Inline(..)););
+    (x_dynamic  $x:expr, $y:expr) => (check_type!(check_type_x, $x, Dynamic(..)););
+    (y_static   $x:expr, $y:expr) => (check_type!(check_type_y, $y, Static(..)););
+    (y_inline   $x:expr, $y:expr) => (check_type!(check_type_y, $y, Inline(..)););
+    (y_dynamic  $x:expr, $y:expr) => (check_type!(check_type_y, $y, Dynamic(..)););
+    (is_static  $x:expr, $y:expr) => (bench_one!(x_static  $x, $y); bench_one!(y_static  $x, $y););
+    (is_inline  $x:expr, $y:expr) => (bench_one!(x_inline  $x, $y); bench_one!(y_inline  $x, $y););
+    (is_dynamic $x:expr, $y:expr) => (bench_one!(x_dynamic $x, $y); bench_one!(y_dynamic $x, $y););
 
-    (eq $x:expr, $_y:expr) => (bench_tiny_op!(eq_x_1000, eq, $x, $x));
-    (ne $x:expr, $y:expr)  => (bench_tiny_op!(ne_x_1000, ne, $x, $y));
-    (lt $x:expr, $y:expr)  => (bench_tiny_op!(lt_x_1000, lt, $x, $y));
+    (eq $x:expr, $_y:expr) => (bench_tiny_op!(eq_x_1000, eq, $x, $x););
+    (ne $x:expr, $y:expr)  => (bench_tiny_op!(ne_x_1000, ne, $x, $y););
+    (lt $x:expr, $y:expr)  => (bench_tiny_op!(lt_x_1000, lt, $x, $y););
 
     (intern $x:expr, $_y:expr) => (
         #[bench]
@@ -122,7 +122,7 @@ macro_rules! bench_one (
             });
         }
     );
-)
+);
 
 macro_rules! bench_all (
     ([ $($which:ident)+ ] for $name:ident = $x:expr, $y:expr) => (
@@ -135,6 +135,7 @@ macro_rules! bench_all (
             use collections::vec::Vec;
             use test::{Bencher, black_box};
             use std::string::ToString;
+            use std::iter::repeat;
 
             use atom::Atom;
             use atom::repr::{Static, Inline, Dynamic};
@@ -142,54 +143,54 @@ macro_rules! bench_all (
             use super::mk;
 
             $(
-                bench_one!($which $x, $y)
+                bench_one!($which $x, $y);
             )+
         }
     );
-)
+);
 
 pub const longer_dynamic_a: &'static str
     = "Thee Silver Mt. Zion Memorial Orchestra & Tra-La-La Band";
 pub const longer_dynamic_b: &'static str
     = "Thee Silver Mt. Zion Memorial Orchestra & Tra-La-La Ban!";
 
-bench_all!([eq ne lt clone_string] for short_string = "e", "f")
-bench_all!([eq ne lt clone_string] for medium_string = "xyzzy01", "xyzzy02")
+bench_all!([eq ne lt clone_string] for short_string = "e", "f");
+bench_all!([eq ne lt clone_string] for medium_string = "xyzzy01", "xyzzy02");
 bench_all!([eq ne lt clone_string]
-    for longer_string = super::longer_dynamic_a, super::longer_dynamic_b)
+    for longer_string = super::longer_dynamic_a, super::longer_dynamic_b);
 
 bench_all!([eq ne intern as_slice clone is_static lt]
-    for static_atom = atom!(a), atom!(b))
+    for static_atom = atom!(a), atom!(b));
 
 bench_all!([intern as_slice clone is_inline]
-    for short_inline_atom = mk("e"), mk("f"))
+    for short_inline_atom = mk("e"), mk("f"));
 
 bench_all!([eq ne intern as_slice clone is_inline lt]
-    for medium_inline_atom = mk("xyzzy01"), mk("xyzzy02"))
+    for medium_inline_atom = mk("xyzzy01"), mk("xyzzy02"));
 
 bench_all!([intern as_slice clone is_dynamic]
-    for min_dynamic_atom = mk("xyzzy001"), mk("xyzzy002"))
+    for min_dynamic_atom = mk("xyzzy001"), mk("xyzzy002"));
 
 bench_all!([eq ne intern as_slice clone is_dynamic lt]
-    for longer_dynamic_atom = mk(super::longer_dynamic_a), mk(super::longer_dynamic_b))
+    for longer_dynamic_atom = mk(super::longer_dynamic_a), mk(super::longer_dynamic_b));
 
 bench_all!([intern as_slice clone is_static]
-    for static_at_runtime = mk("a"), mk("b"))
+    for static_at_runtime = mk("a"), mk("b"));
 
 bench_all!([ne lt x_static y_inline]
-    for static_vs_inline  = atom!(a), mk("f"))
+    for static_vs_inline  = atom!(a), mk("f"));
 
 bench_all!([ne lt x_static y_dynamic]
-    for static_vs_dynamic = atom!(a), mk(super::longer_dynamic_b))
+    for static_vs_dynamic = atom!(a), mk(super::longer_dynamic_b));
 
 bench_all!([ne lt x_inline y_dynamic]
-    for inline_vs_dynamic = mk("e"), mk(super::longer_dynamic_b))
+    for inline_vs_dynamic = mk("e"), mk(super::longer_dynamic_b));
 
 macro_rules! bench_rand ( ($name:ident, $len:expr) => (
     #[bench]
     fn $name(b: &mut Bencher) {
         use std::{str, rand};
-        use std::slice::{SlicePrelude, AsSlice};
+        use std::slice::{AsSlice, SliceExt};
         use std::rand::Rng;
 
         let mut gen = rand::weak_rng();
@@ -200,19 +201,19 @@ macro_rules! bench_rand ( ($name:ident, $len:expr) => (
             // I measured the overhead of random string generation
             // as about 3-12% at one point.
 
-            let mut buf: [u8, ..$len] = [0, ..$len];
+            let mut buf: [u8; $len] = [0; $len];
             gen.fill_bytes(buf.as_mut_slice());
             for n in buf.iter_mut() {
                 // shift into printable ASCII
                 *n = (*n % 0x40) + 0x20;
             }
-            let s = unsafe { str::raw::from_utf8(buf.as_slice()) };
+            let s = unsafe { str::from_utf8(buf.as_slice()).unwrap() };
             black_box(Atom::from_slice(s));
         });
     }
-))
+));
 
-bench_rand!(intern_rand_008,   8)
-bench_rand!(intern_rand_032,  32)
-bench_rand!(intern_rand_128, 128)
-bench_rand!(intern_rand_512, 512)
+bench_rand!(intern_rand_008,   8);
+bench_rand!(intern_rand_032,  32);
+bench_rand!(intern_rand_128, 128);
+bench_rand!(intern_rand_512, 512);

--- a/src/atom/bench.rs
+++ b/src/atom/bench.rs
@@ -207,7 +207,7 @@ macro_rules! bench_rand ( ($name:ident, $len:expr) => (
                 // shift into printable ASCII
                 *n = (*n % 0x40) + 0x20;
             }
-            let s = unsafe { str::from_utf8(buf.as_slice()).unwrap() };
+            let s = str::from_utf8(buf.as_slice()).unwrap();
             black_box(Atom::from_slice(s));
         });
     }

--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -298,7 +298,6 @@ mod bench;
 mod tests {
     use core::prelude::*;
 
-    use std::fmt;
     use std::thread::Thread;
     use super::Atom;
     use super::repr::{Static, Inline, Dynamic};

--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -12,7 +12,7 @@
 use core::prelude::*;
 
 use phf::OrderedSet;
-use xxhash::XXHasher;
+use xxhash;
 
 use core::fmt;
 use core::iter::RandomAccessIterator;
@@ -47,7 +47,6 @@ const ENTRY_ALIGNMENT: uint = 16;
 static static_atom_set: OrderedSet<&'static str> = static_atom_set!();
 
 struct StringCache {
-    hasher: XXHasher,
     buckets: [*mut StringCacheEntry; 4096],
 }
 
@@ -78,13 +77,12 @@ impl StringCacheEntry {
 impl StringCache {
     fn new() -> StringCache {
         StringCache {
-            hasher: XXHasher::new(),
             buckets: unsafe { mem::zeroed() },
         }
     }
 
     fn add(&mut self, string_to_add: &str) -> *mut StringCacheEntry {
-        let hash = self.hasher.hash(&string_to_add);
+        let hash = xxhash::hash(&string_to_add);
         let bucket_index = (hash & (self.buckets.len()-1) as u64) as uint;
         let mut ptr = self.buckets[bucket_index];
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -33,4 +33,4 @@ pub fn log(e: Event) {
     LOG.lock().push(e);
 }
 
-macro_rules! log (($e:expr) => (::event::log($e)))
+macro_rules! log (($e:expr) => (::event::log($e)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@
 #![crate_name = "string_cache"]
 #![crate_type = "rlib"]
 
-#![feature(phase, macro_rules, default_type_params, globs, old_orphan_check)]
+#![feature(plugin, old_orphan_check)]
 #![no_std]
 
-#[phase(plugin, link)]
+#[macro_use]
 extern crate core;
 
 extern crate alloc;
@@ -24,16 +24,17 @@ extern crate test;
 
 extern crate std;
 
-#[phase(plugin)]
+#[plugin]
 extern crate phf_mac;
 extern crate phf;
 
-#[phase(plugin)]
+#[macro_use]
 extern crate lazy_static;
 
 extern crate xxhash;
 
-#[phase(plugin)]
+#[plugin]
+#[macro_use]
 extern crate string_cache_macros;
 
 #[cfg(feature = "log-events")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![crate_name = "string_cache"]
 #![crate_type = "rlib"]
 
-#![feature(phase, macro_rules, default_type_params, globs)]
+#![feature(phase, macro_rules, default_type_params, globs, old_orphan_check)]
 #![no_std]
 
 #[phase(plugin, link)]

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -16,11 +16,11 @@ use atom::Atom;
 /// An atom that is meant to represent a namespace in the HTML / XML sense.
 /// Whether a given string represents a namespace is contextual, so this is
 /// a transparent wrapper that will not catch all mistakes.
-#[deriving(PartialEq, Eq, PartialOrd, Ord, Hash, Show, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Show, Clone)]
 pub struct Namespace(pub Atom);
 
 /// A name with a namespace.
-#[deriving(PartialEq, Eq, PartialOrd, Ord, Hash, Show, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Show, Clone)]
 pub struct QualName {
     pub ns: Namespace,
     pub local: Atom,


### PR DESCRIPTION
* Macro syntax changed (mandatory closing semicolon).
* Array sytanx changed (`[ty, ..n]` replaced by `[ty; n]`).
* Enums became namespaced.
* `proc()` syntax got replaced by `move ||`.
* `#[deriving(x)]` became deprected and got replaced by `#[derive(x)]`.
* Some APIs changed (around pointers, slices, vectors, hashes, locks, strings, threads).