### PR TITLE
Set up Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+env:
+  global:
+      - secure: uytPp0Fs+LT3QDEhDM3LJWiLvT2AHbdWnXrPEs+bYshQwt9wST+KQnYLyRfBuGg2ux3pkZwsRUFexvN8pQ3ab4aU2P21Xo98TzdXRwXurNYePgk/3tykEH+JrL52DfjCWB1VsjzzFrP02XU0XtB30qWC/n+fxeMWT7JT2GVh/OE=
+language: rust
+script:
+  - cargo build
+  - cargo test
+after_script:
+  - cd target
+  - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh


### PR DESCRIPTION
This was heavily based on [servo/html5ever's `.travis.yml` file](https://github.com/servo/html5ever/blob/3d4258abcf9b1d14671088925a350ece64c698ee/.travis.yml).