### PR TITLE
Upgrade to rustc 1.0.0-nightly (4db0b3246 2015-02-25) (built 2015-02-26)

### DIFF
--- a/examples/event-log/Cargo.toml
+++ b/examples/event-log/Cargo.toml
@@ -5,5 +5,5 @@ version = "0.0.0"
 authors = [ "The Servo Project Developers" ]
 
 [dependencies.string_cache]
-git = "https://github.com/servo/string-cache"
+path = "../.."
 features = ["log-events"]

--- a/examples/summarize-events/Cargo.toml
+++ b/examples/summarize-events/Cargo.toml
@@ -9,4 +9,4 @@ csv = "0"
 rustc-serialize = "0"
 
 [dependencies.string_cache]
-git = "https://github.com/servo/string-cache"
+path = "../.."

--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -56,7 +56,7 @@ struct StringCacheEntry {
     string: String,
 }
 
-unsafe impl Send for *mut StringCacheEntry { }
+unsafe impl Send for StringCache { }
 
 impl StringCacheEntry {
     fn new(next: *mut StringCacheEntry, hash: u64, string_to_add: &str) -> StringCacheEntry {


### PR DESCRIPTION
This makes it build again, but it have no idea what I’m doing. Please review for memory safety.

libcore now has ` impl<T> !Send for *mut T { }`, which might be what causes:

```
src/atom/mod.rs:59:1: 59:42 error: conflicting implementations for trait `core::marker::Send` [E0119]
src/atom/mod.rs:59 unsafe impl Send for *mut StringCacheEntry { }
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/atom/mod.rs:59:1: 59:42 note: conflicting implementation in crate `core`
src/atom/mod.rs:59 unsafe impl Send for *mut StringCacheEntry { }
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```