### PR TITLE
Remove usage of #[static_assert]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: rust
+rust: nightly
 script:
   - cargo test
   - cargo clean

--- a/examples/summarize-events/Cargo.toml
+++ b/examples/summarize-events/Cargo.toml
@@ -10,3 +10,6 @@ rustc-serialize = "0"
 
 [dependencies.string_cache]
 path = "../.."
+
+[dependencies.string_cache_shared]
+path = "../../shared"

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -10,7 +10,7 @@
 #![crate_name="string_cache_plugin"]
 #![crate_type="dylib"]
 
-#![feature(plugin_registrar, quote, box_syntax, static_assert)]
+#![feature(plugin_registrar, quote, box_syntax)]
 #![feature(rustc_private, slice_patterns)]
 #![deny(warnings)]
 #![allow(unused_imports)]  // for quotes

--- a/shared/lib.rs
+++ b/shared/lib.rs
@@ -11,7 +11,7 @@
 //! the macros crate and the run-time library, in order to guarantee
 //! consistency.
 
-#![feature(core, static_assert)]
+#![feature(core)]
 #![deny(warnings)]
 
 use std::{mem, raw, intrinsics};
@@ -42,11 +42,9 @@ pub enum UnpackedAtom {
 
 const STATIC_SHIFT_BITS: usize = 32;
 
+#[cfg(target_endian = "little")]  // Not implemented yet for big-endian
 #[inline(always)]
 unsafe fn inline_atom_slice(x: &u64) -> raw::Slice<u8> {
-    #[static_assert]
-    const _IS_LITTLE_ENDIAN: bool = cfg!(target_endian = "little");
-
     let x: *const u64 = x;
     raw::Slice {
         data: (x as *const u8).offset(1),
@@ -82,8 +80,7 @@ impl UnpackedAtom {
 
     #[inline(always)]
     pub unsafe fn from_packed(data: u64) -> UnpackedAtom {
-        #[static_assert]
-        const _DYNAMIC_IS_UNTAGGED: bool = DYNAMIC_TAG == 0;
+        debug_assert!(DYNAMIC_TAG == 0); // Dynamic is untagged
 
         match (data & 0xf) as u8 {
             DYNAMIC_TAG => Dynamic(data as *mut ()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![crate_name = "string_cache"]
 #![crate_type = "rlib"]
 
-#![feature(plugin, unsafe_no_drop_flag, static_assert)]
+#![feature(plugin, unsafe_no_drop_flag)]
 #![feature(core, collections, alloc, hash)]
 #![deny(warnings)]
 #![cfg_attr(test, feature(test))]


### PR DESCRIPTION
It’s <s>probably going away</s> gone: https://github.com/rust-lang/rfcs/pull/1096