### PR TITLE
Bump version: 0.1.4 -> 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache"
-version = "0.1.4"
+version = "0.1.5"
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT / Apache-2.0"


### PR DESCRIPTION
I need this in a released version:

https://github.com/servo/string-cache/pull/90