### PR TITLE
Reuse phf hash and remove phf::OrderedSet indirection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache"
-version = "0.1.10"
+version = "0.1.11"
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT / Apache-2.0"
@@ -37,13 +37,13 @@ optional = true
 
 [dependencies.string_cache_plugin]
 path = "plugin"
-version = "0.1.5"
+version = "0.1.7"
 optional = true
 
 [dependencies.string_cache_shared]
 path = "shared"
-version = "0.1.4"
+version = "0.1.6"
 
 [build-dependencies.string_cache_shared]
 path = "shared"
-version = "0.1.4"
+version = "0.1.6"

--- a/build.rs
+++ b/build.rs
@@ -44,7 +44,7 @@ fn generate_combination(prefix1: String, suffix: &str, url: &str, file: &mut Buf
 }
 
 fn atom(s: &str) -> String {
-    let data = pack_static(STATIC_ATOM_SET.get_index(s).unwrap() as u32);
+    let data = pack_static(STATIC_ATOM_SET.get_index_or_hash(s).unwrap() as u32);
     format!("$crate::Atom {{ data: 0x{:x} }}", data)
 }
 

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache_plugin"
-version = "0.1.6"
+version = "0.1.7"
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project − compiler plugin."
 license = "MIT / Apache-2.0"
@@ -14,7 +14,7 @@ plugin = true
 
 [dependencies.string_cache_shared]
 path = "../shared"
-version = "0.1.0"
+version = "0.1.6"
 
 [dependencies]
 lazy_static = "0.1.10"

--- a/plugin/src/atom/mod.rs
+++ b/plugin/src/atom/mod.rs
@@ -44,9 +44,9 @@ impl MacResult for AtomResult {
 }
 
 fn make_atom_result(cx: &mut ExtCtxt, name: &str) -> Option<AtomResult> {
-    let i = match ::string_cache_shared::STATIC_ATOM_SET.get_index(name) {
-        Some(i) => i,
-        None => return None,
+    let i = match ::string_cache_shared::STATIC_ATOM_SET.get_index_or_hash(name) {
+        Ok(i) => i,
+        Err(_hash) => return None,
     };
 
     let data = ::string_cache_shared::pack_static(i as u32);

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache_shared"
-version = "0.1.5"
+version = "0.1.6"
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project − shared code between the compiler plugin and main crate."
 license = "MIT / Apache-2.0"
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 debug_unreachable = "0.0.6"
-phf_shared = "0.7.3"
+phf_shared = "0.7.4"
 
 [build-dependencies]
-phf_generator = "0.7.3"
+phf_generator = "0.7.4"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 debug_unreachable = "0.0.6"
-phf = "0.7.3"
+phf_shared = "0.7.3"
 
 [build-dependencies]
-phf_codegen = "0.7.3"
+phf_generator = "0.7.3"

--- a/shared/build.rs
+++ b/shared/build.rs
@@ -1,4 +1,4 @@
-extern crate phf_codegen;
+extern crate phf_generator;
 
 mod static_atom_list;
 
@@ -7,14 +7,31 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 fn main() {
-    let mut set = phf_codegen::OrderedSet::new();
-    for &atom in static_atom_list::ATOMS {
-        set.entry(atom);
+    let mut set = std::collections::HashSet::new();
+    for atom in static_atom_list::ATOMS {
+        if !set.insert(atom) {
+            panic!("duplicate static atom `{:?}`", atom);
+        }
     }
+
+    let state = phf_generator::generate_hash(static_atom_list::ATOMS);
 
     let path = Path::new(&std::env::var("OUT_DIR").unwrap()).join("static_atom_set.rs");
     let mut file = BufWriter::new(File::create(&path).unwrap());
-    write!(&mut file, "pub static STATIC_ATOM_SET: phf::OrderedSet<&'static str> = ").unwrap();
-    set.build(&mut file).unwrap();
-    write!(&mut file, ";\n").unwrap();
+    macro_rules! w {
+        ($($arg: expr),+) => { (writeln!(&mut file, $($arg),+).unwrap()) }
+    }
+    w!("pub static STATIC_ATOM_SET: StaticAtomSet = StaticAtomSet {{");
+    w!("    key: {},", state.key);
+    w!("    disps: &[");
+    for &(d1, d2) in &state.disps {
+        w!("        ({}, {}),", d1, d2);
+    }
+    w!("    ],");
+    w!("    atoms: &[");
+    for &idx in &state.map {
+        w!("        {:?},", static_atom_list::ATOMS[idx]);
+    }
+    w!("    ],");
+    w!("}};");
 }

--- a/shared/lib.rs
+++ b/shared/lib.rs
@@ -40,13 +40,13 @@ pub struct StaticAtomSet {
 
 impl StaticAtomSet {
     #[inline]
-    pub fn get_index(&self, s: &str) -> Option<u32> {
+    pub fn get_index_or_hash(&self, s: &str) -> Result<u32, u64> {
         let hash = phf_shared::hash(s, self.key);
         let index = phf_shared::get_index(hash, self.disps, self.atoms.len());
         if self.atoms[index as usize] == s {
-            Some(index)
+            Ok(index)
         } else {
-            None
+            Err(hash)
         }
     }
 

--- a/shared/static_atom_list.rs
+++ b/shared/static_atom_list.rs
@@ -9,12 +9,7 @@
 
 pub static ATOMS: &'static [&'static str] = &[
 
-    // The first 64 atoms are special: we can quickly check membership
-    // in sets of these, using a bitmask.  This includes every tag that
-    // appears in more than one set in the tree builder spec, plus a
-    // few others (arbitrarily chosen).
-    //
-    // FIXME(kmc): check if this is really true with the packed tag bits
+    // The order is not preserved by phf.
 
     "a",
     "address",
@@ -80,8 +75,6 @@ pub static ATOMS: &'static [&'static str] = &[
     "tr",
     "track",
     "xmp",
-
-    // End of first 64 atoms.
 
     "",
 


### PR DESCRIPTION
<s>Do not merge yet.</s> This depends on https://github.com/sfackler/rust-phf/pull/62

Use the `phf_shared` and `phf_generator` crates directly instead of `phf`. This allows us to re-use the phf hash in the dynamic table and avoid hashing the same string again.

Also remove the indirection of `phf::OrderedSet` compared to `phf::Set`: we don’t care about the order, only about getting numeric indices. (The optimization mentioned in a comment of using a bit map of the first 64 atoms in the html5ever tree builder was never implemented. If we want it, the indirection and order preservation can be added back while preserving the hash reuse.)

Fixes #38.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/103)
<!-- Reviewable:end -->
