### PR TITLE
Bump version to 0.1.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache"
-version = "0.1.12"
+version = "0.1.13"
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT / Apache-2.0"


### PR DESCRIPTION
I need d3cee6feb4c23af7aaa435e2cfa8703857b32953 for an upcoming Servo PR, so I need a new version published

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/111)
<!-- Reviewable:end -->
