### PR TITLE
Add non-mutating AsciiExt methods to Atom.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache"
-version = "0.2.4"
+version = "0.2.5"
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT / Apache-2.0"


### PR DESCRIPTION
Add the following methods from AsciiExt:

```
pub fn is_ascii(&self) -> bool;
pub fn to_ascii_uppercase(&self) -> Atom;
pub fn to_ascii_lowercase(&self) -> Atom;
pub fn eq_ignore_ascii_case(&self, other: &Self) -> bool;
```

We can't implement AsciiExt in full because it requires mutable access.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/134)
<!-- Reviewable:end -->
