### PR TITLE
add dirname atom for HTMLInputElement attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache"
-version = "0.2.11"
+version = "0.2.12"
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT / Apache-2.0"

--- a/src/static_atom_list.rs
+++ b/src/static_atom_list.rs
@@ -379,6 +379,7 @@ pub static ATOMS: &'static [&'static str] = &[
     "diffuseConstant",
     "dir",
     "direction",
+    "dirname",
     "disabled",
     "discard",
     "display",


### PR DESCRIPTION
related to servo issue : https://github.com/servo/servo/issues/10491

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/148)
<!-- Reviewable:end -->
