### PR TITLE
Define Atom::get_hash().

### DIFF
--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -176,6 +176,10 @@ impl Atom {
     unsafe fn unpack(&self) -> UnpackedAtom {
         UnpackedAtom::from_packed(self.data)
     }
+
+    pub fn get_hash(&self) -> u32 {
+        ((self.data >> 32) ^ self.data) as u32
+    }
 }
 
 impl<'a> From<Cow<'a, str>> for Atom {


### PR DESCRIPTION
This is already used by rust-selectors for its Bloom filter, and is
implemented there by accessing the data field directly.

Also, in a Gecko-based Atom implementation, the implementation will need to
be different, so it's better to have it here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/149)
<!-- Reviewable:end -->
