### PR TITLE
Tweak string-cache to be compatible with the gecko-atom override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache"
-version = "0.2.15"
+version = "0.2.16"
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT / Apache-2.0"

--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -171,6 +171,21 @@ pub struct Atom {
     pub data: u64,
 }
 
+pub struct BorrowedAtom<'a>(pub &'a Atom);
+
+impl<'a> ops::Deref for BorrowedAtom<'a> {
+    type Target = Atom;
+    fn deref(&self) -> &Atom {
+        self.0
+    }
+}
+
+impl<'a> PartialEq<Atom> for BorrowedAtom<'a> {
+    fn eq(&self, other: &Atom) -> bool {
+        self.0 == other
+    }
+}
+
 impl Atom {
     #[inline(always)]
     unsafe fn unpack(&self) -> UnpackedAtom {
@@ -179,6 +194,11 @@ impl Atom {
 
     pub fn get_hash(&self) -> u32 {
         ((self.data >> 32) ^ self.data) as u32
+    }
+
+    pub fn with_str<F, Output>(&self, cb: F) -> Output
+                               where F: FnOnce(&str) -> Output {
+        cb(self)
     }
 }
 
@@ -376,7 +396,11 @@ impl Atom {
     }
 
     pub fn eq_ignore_ascii_case(&self, other: &Self) -> bool {
-        (self == other) || (&**self).eq_ignore_ascii_case(&**other)
+        (self == other) || self.eq_str_ignore_ascii_case(&**other)
+    }
+
+    pub fn eq_str_ignore_ascii_case(&self, other: &str) -> bool {
+        (&**self).eq_ignore_ascii_case(other)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@
 extern crate serde;
 extern crate phf_shared;
 
-pub use atom::Atom;
-pub use namespace::{Namespace, QualName};
+pub use atom::{Atom, BorrowedAtom};
+pub use namespace::{BorrowedNamespace, Namespace, QualName};
 
 #[macro_export]
 macro_rules! qualname {

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -10,6 +10,7 @@
 //! **Note:** This may move as string-cache becomes less Web-specific.
 
 use atom::Atom;
+use std::ops;
 
 /// An atom that is meant to represent a namespace in the HTML / XML sense.
 /// Whether a given string represents a namespace is contextual, so this is
@@ -17,6 +18,21 @@ use atom::Atom;
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone)]
 #[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 pub struct Namespace(pub Atom);
+
+pub struct BorrowedNamespace<'a>(pub &'a Namespace);
+
+impl<'a> ops::Deref for BorrowedNamespace<'a> {
+    type Target = Namespace;
+    fn deref(&self) -> &Namespace {
+        self.0
+    }
+}
+
+impl<'a> PartialEq<Namespace> for BorrowedNamespace<'a> {
+    fn eq(&self, other: &Namespace) -> bool {
+        self.0 == other
+    }
+}
 
 /// A name with a namespace.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone)]

--- a/src/static_atom_list.rs
+++ b/src/static_atom_list.rs
@@ -103,6 +103,13 @@ pub static ATOMS: &'static [&'static str] = &[
     "Netscape",
     "Win32",
 
+    // Font families
+    "serif",
+    "sans-serif",
+    "cursive",
+    "fantasy",
+    "monospace",
+
     "abbr",
     "abort",
     "abs",
@@ -1054,7 +1061,6 @@ pub static ATOMS: &'static [&'static str] = &[
     "sep",
     "separator",
     "separators",
-    "serif",
     "set",
     "setdiff",
     "shape",


### PR DESCRIPTION
I have a Servo branch that introduces an atom crate for geckolib that is semantically compatible with string-cache but backed by gecko atoms.

I needed to tweak a few things though, so here are the changes required in string-cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/155)
<!-- Reviewable:end -->
