### PR TITLE
[WIP] Add stable/unstable branching so Atom can contain NonZero<u64>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,17 @@
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(all(test, feature = "unstable"), feature(test, filling_drop))]
 #![cfg_attr(feature = "unstable", feature(unsafe_no_drop_flag))]
+#![cfg_attr(feature = "unstable", feature(nonzero))]
 #![cfg_attr(feature = "heap_size", feature(plugin, custom_derive))]
 #![cfg_attr(feature = "heap_size", plugin(heapsize_plugin))]
 
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 #[cfg(feature = "log-events")] extern crate rustc_serialize;
 #[cfg(feature = "heap_size")] extern crate heapsize;
+
+// Don't need to define, because it's done in the generated `atom_macro.rs` (?)
+//#[cfg(feature = "unstable")] extern crate core;
+
 #[cfg(test)] extern crate rand;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate debug_unreachable;


### PR DESCRIPTION
The macro isn't entirely fixed. Anywhere in which it is used, the consumer has to manually:
```
extern crate core;
use core::nonzero::NonZero;
```
which is a bit of a bummer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/156)
<!-- Reviewable:end -->
