### PR TITLE
add onstatechange to static_atom_list

### DIFF
--- a/src/static_atom_list.rs
+++ b/src/static_atom_list.rs
@@ -892,6 +892,7 @@ pub static ATOMS: &'static [&'static str] = &[
     "onscroll",
     "onselect",
     "onselectstart",
+    "onstatechange",
     "onstart",
     "onstop",
     "onstorage",


### PR DESCRIPTION
Required for [onstatechange](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-onstatechange-attribute) on Service Workers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/158)
<!-- Reviewable:end -->
