### PR TITLE
Rename Atom::data to unsafe_data and hide it in docs.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -61,7 +61,7 @@ fn write_atom_macro(hash_state: &phf_generator::HashState) {
     writeln!(file, r"macro_rules! atom {{").unwrap();
     for &s in set.iter() {
         let data = shared::pack_static(set.get_index_or_hash(s).unwrap() as u32);
-        writeln!(file, r"({:?}) => {{ $crate::Atom {{ data: 0x{:x} }} }};", s, data).unwrap();
+        writeln!(file, r"({:?}) => {{ $crate::Atom {{ unsafe_data: 0x{:x} }} }};", s, data).unwrap();
     }
     writeln!(file, r"}}").unwrap();
 }

--- a/examples/summarize-events/src/main.rs
+++ b/examples/summarize-events/src/main.rs
@@ -88,7 +88,7 @@ fn main() {
 
                     // FIXME: We really shouldn't be allowed to do this. It's a memory-safety
                     // hazard; the field is only public for the atom!() macro.
-                    _ => Atom { data: ev.id }.to_string(),
+                    _ => Atom { unsafe_data: ev.id }.to_string(),
                 };
 
                 match summary.entry(string) {


### PR DESCRIPTION
r? @nox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/160)
<!-- Reviewable:end -->
