### PR TITLE
Make cmp massively faster for inline atoms

### DIFF
--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -322,7 +322,7 @@ impl ops::Deref for Atom {
             match self.unpack() {
                 Inline(..) => {
                     let buf = inline_orig_bytes(&self.unsafe_data);
-                    str::from_utf8(buf).unwrap()
+                    str::from_utf8_unchecked(buf)
                 },
                 Static(idx) => STATIC_ATOM_SET.index(idx).expect("bad static atom"),
                 Dynamic(entry) => {


### PR DESCRIPTION
This is a big deal if you're putting atoms inside a btreeset since it does a lot of cmp operations.

It's more unsafe, but

1. the only thing that constructs `Inline` atoms should be the `string-cache` code (which I've been utilising fairly heavily)
2. if `string-cache` code *isn't* the only thing constructing atoms, `Dynamic` atoms are wildly unsafe since they contain pointers
3. since the creation of `Inline` atoms is only dependent on length of string (not content) you can exhaustively check correctness just by inlining and derefing strings from `"a"` to `"aaaaaaa"`. I can add an explicit test for this if you like.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/175)
<!-- Reviewable:end -->
