### PR TITLE
Make tests pass on a 32-bit system.

### DIFF
--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -723,7 +723,8 @@ mod tests {
         // Guard against accidental changes to the sizes of things.
         assert_eq!(mem::size_of::<super::Atom>(),
                    if compiler_uses_inline_drop_flags { 16 } else { 8 });
-        assert_eq!(40, mem::size_of::<super::StringCacheEntry>());
+        assert_eq!(mem::size_of::<super::StringCacheEntry>(),
+                   8 + 4 * mem::size_of::<usize>());
     }
 
     #[test]


### PR DESCRIPTION
Testable on 64-bit Linux with:

```
rustup target add i686-unknown-linux-gnu
cargo test --target i686-unknown-linux-gnu
```

(or similarly on anther 64-bit platforms), assuming a linker and libc for this target are available on the system.

Leaving #162 open to add CI for this. (Unfortunately Travis doesn’t use rustup out of the box.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/176)
<!-- Reviewable:end -->
