### PR TITLE
Implement selectors_bloom::BloomHash for Atom and Namespace.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache"
-version = "0.2.30"
+version = "0.2.31"
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT / Apache-2.0"
@@ -29,6 +29,7 @@ lazy_static = "0.2"
 serde = ">=0.6, <0.9"
 phf_shared = "0.7.4"
 debug_unreachable = "0.1.1"
+selectors-bloom = "0.1"
 
 [dev-dependencies]
 rand = "0.3"

--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -201,6 +201,7 @@ impl Atom {
         UnpackedAtom::from_packed(self.unsafe_data)
     }
 
+    #[inline]
     pub fn get_hash(&self) -> u32 {
         ((self.unsafe_data >> 32) ^ self.unsafe_data) as u32
     }
@@ -393,6 +394,13 @@ impl Deserialize for Atom {
     fn deserialize<D>(deserializer: &mut D) -> Result<Atom,D::Error> where D: Deserializer {
         let string: String = try!(Deserialize::deserialize(deserializer));
         Ok(Atom::from(&*string))
+    }
+}
+
+impl ::selectors_bloom::BloomHash for Atom {
+    #[inline]
+    fn bloom_hash(&self) -> u32 {
+        self.get_hash()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 #[macro_use] extern crate debug_unreachable;
 extern crate serde;
 extern crate phf_shared;
+extern crate selectors_bloom;
 
 pub use atom::{Atom, BorrowedAtom};
 pub use namespace::{BorrowedNamespace, Namespace, QualName};

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -44,6 +44,13 @@ impl fmt::Display for Namespace {
     }
 }
 
+impl ::selectors_bloom::BloomHash for Namespace {
+    #[inline]
+    fn bloom_hash(&self) -> u32 {
+        self.0.get_hash()
+    }
+}
+
 /// A name with a namespace.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone)]
 pub struct QualName {


### PR DESCRIPTION
This new dependency is temporary. With https://github.com/servo/string-cache/pull/136 it’ll go into html5ever. In the meantime, this PR allows updating selectors in Servo for https://github.com/servo/rust-selectors/pull/100.

r? @nox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/177)
<!-- Reviewable:end -->
