### PR TITLE
Expose the precomputed hash using a trait so that I can use it from rust-selectors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log-events = ["rustc-serialize"]
 unstable = []
 
 [dependencies]
+precomputed-hash = "0.1"
 lazy_static = "0.2"
 serde = "0.9"
 phf_shared = "0.7.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,9 @@
 #[cfg(test)] extern crate rand;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate debug_unreachable;
-extern crate serde;
 extern crate phf_shared;
+extern crate precomputed_hash;
+extern crate serde;
 extern crate string_cache_shared as shared;
 
 pub use atom::{Atom, StaticAtomSet, PhfStrSet, EmptyStaticAtomSet, DefaultAtom};

--- a/string-cache-codegen/Cargo.toml
+++ b/string-cache-codegen/Cargo.toml
@@ -15,4 +15,5 @@ path = "lib.rs"
 [dependencies]
 string_cache_shared = {path = "../shared", version = "0.3"}
 phf_generator = "0.7.15"
+phf_shared = "0.7.4"
 quote = "0.3.9"


### PR DESCRIPTION
This allows us to get rid of the extra hashing overhead every time we check the
bloom filter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/183)
<!-- Reviewable:end -->
