### PR TITLE
Make to_ascii_{upper,lower}case more efficent.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache"
-version = "0.5.0"  # Also update README.md when making a semver-breaking change
+version = "0.5.1"  # Also update README.md when making a semver-breaking change
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT / Apache-2.0"

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -470,19 +470,21 @@ impl<Static: StaticAtomSet> Deserialize for Atom<Static> {
 // over the one from &str.
 impl<Static: StaticAtomSet> Atom<Static> {
     pub fn to_ascii_uppercase(&self) -> Self {
-        if self.chars().all(char::is_uppercase) {
-            self.clone()
-        } else {
-            Atom::from(&*((&**self).to_ascii_uppercase()))
+        for b in self.bytes() {
+            if let b'a' ... b'z' = b {
+                return Atom::from((&**self).to_ascii_uppercase())
+            }
         }
+        self.clone()
     }
 
     pub fn to_ascii_lowercase(&self) -> Self {
-        if self.chars().all(char::is_lowercase) {
-            self.clone()
-        } else {
-            Atom::from(&*((&**self).to_ascii_lowercase()))
+        for b in self.bytes() {
+            if let b'A' ... b'Z' = b {
+                return Atom::from((&**self).to_ascii_lowercase())
+            }
         }
+        self.clone()
     }
 
     pub fn eq_ignore_ascii_case(&self, other: &Self) -> bool {


### PR DESCRIPTION
* Use `From<String> for Atom`
* Use the fast path with non-letters too

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/186)
<!-- Reviewable:end -->
