### PR TITLE
Update to serde 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ unstable = []
 [dependencies]
 precomputed-hash = "0.1"
 lazy_static = "0.2"
-serde = "0.9"
+serde = "1"
 phf_shared = "0.7.4"
 debug_unreachable = "0.1.1"
 heapsize = { version = "0.3", optional = true }

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -458,8 +458,8 @@ impl<Static: StaticAtomSet> Serialize for Atom<Static> {
     }
 }
 
-impl<Static: StaticAtomSet> Deserialize for Atom<Static> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer {
+impl<'a, Static: StaticAtomSet> Deserialize<'a> for Atom<Static> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'a> {
         let string: String = try!(Deserialize::deserialize(deserializer));
         Ok(Atom::from(string))
     }


### PR DESCRIPTION
Hi there!

I was just thinking the other day about how much I really didn't want to write a string interner and lo-and-behold one already exists! And it works!

This is just a really quick PR to update to stable `serde 1.0`. I could write a test to confirm items are deserialised to the interned value rather than allocating but that doesn't seem to be a thing that's done in other tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/187)
<!-- Reviewable:end -->
