### PR TITLE
Remove `heapsize` dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   - cargo test
   - cargo test --features log-events
   - "if [ $TRAVIS_RUST_VERSION = nightly ]; then cargo test --features unstable; fi"
-  - cargo test --features heapsize
+  - cargo test
   - "cd string-cache-codegen/ && cargo build && cd .."
   - "cd examples/event-log/ && cargo build && cd ../.."
   - "cd examples/summarize-events/ && cargo build && cd ../.."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache"
-version = "0.6.3"  # Also update README.md when making a semver-breaking change
+version = "0.7.0"  # Also update README.md when making a semver-breaking change
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT / Apache-2.0"
@@ -33,7 +33,6 @@ lazy_static = "0.2"
 serde = "1"
 phf_shared = "0.7.4"
 debug_unreachable = "0.1.1"
-heapsize = { version = ">= 0.3, < 0.5", optional = true }
 string_cache_shared = {path = "./shared", version = "0.3"}
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In `Cargo.toml`:
 
 ```toml
 [dependencies]
-string_cache = "0.6"
+string_cache = "0.7"
 ```
 
 In `lib.rs`:
@@ -31,7 +31,7 @@ In `Cargo.toml`:
 build = "build.rs"
 
 [dependencies]
-string_cache = "0.5"
+string_cache = "0.7"
 
 [build-dependencies]
 string_cache_codegen = "0.4"

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -9,9 +9,6 @@
 
 #![allow(non_upper_case_globals)]
 
-#[cfg(feature = "heapsize")]
-use heapsize::HeapSizeOf;
-
 use phf_shared;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -46,26 +43,8 @@ struct StringCache {
     buckets: [Option<Box<StringCacheEntry>>; NB_BUCKETS],
 }
 
-#[cfg(feature = "heapsize")]
-impl HeapSizeOf for StringCache {
-    fn heap_size_of_children(&self) -> usize {
-        self.buckets.iter().fold(0, |size, bucket| size + bucket.heap_size_of_children())
-    }
-}
-
 lazy_static! {
     static ref STRING_CACHE: Mutex<StringCache> = Mutex::new(StringCache::new());
-}
-
-/// A token that represents the heap used by the dynamic string cache.
-#[cfg(feature = "heapsize")]
-pub struct StringCacheHeap;
-
-#[cfg(feature = "heapsize")]
-impl HeapSizeOf for StringCacheHeap {
-    fn heap_size_of_children(&self) -> usize {
-        STRING_CACHE.lock().unwrap().heap_size_of_children()
-    }
 }
 
 struct StringCacheEntry {
@@ -73,14 +52,6 @@ struct StringCacheEntry {
     hash: u64,
     ref_count: AtomicIsize,
     string: Box<str>,
-}
-
-#[cfg(feature = "heapsize")]
-impl HeapSizeOf for StringCacheEntry {
-    fn heap_size_of_children(&self) -> usize {
-        self.next_in_bucket.heap_size_of_children() +
-        self.string.heap_size_of_children()
-    }
 }
 
 impl StringCacheEntry {
@@ -211,14 +182,6 @@ pub struct Atom<Static: StaticAtomSet> {
 
     #[doc(hidden)]
     pub phantom: PhantomData<Static>,
-}
-
-#[cfg(feature = "heapsize")]
-impl<Static: StaticAtomSet> HeapSizeOf for Atom<Static> {
-    #[inline(always)]
-    fn heap_size_of_children(&self) -> usize {
-        0
-    }
 }
 
 impl<Static: StaticAtomSet> ::precomputed_hash::PrecomputedHash for Atom<Static> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 
 #[cfg(all(test, feature = "unstable"))] extern crate test;
-#[cfg(feature = "heapsize")] extern crate heapsize;
 #[cfg(all(test, feature = "unstable"))] extern crate rand;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate debug_unreachable;


### PR DESCRIPTION
The heapsize crate is being deprecated in favour of the malloc_size_of
crate within Servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/196)
<!-- Reviewable:end -->
