### PR TITLE
Switch to fork of debug_unreachable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "string_cache"
-version = "0.7.2"  # Also update README.md when making a semver-breaking change
+version = "0.7.3"  # Also update README.md when making a semver-breaking change
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT / Apache-2.0"
@@ -32,7 +32,7 @@ precomputed-hash = "0.1"
 lazy_static = "1"
 serde = "1"
 phf_shared = "0.7.4"
-debug_unreachable = "0.1.1"
+new_debug_unreachable = "1.0"
 string_cache_shared = {path = "./shared", version = "0.3"}
 
 [dev-dependencies]


### PR DESCRIPTION
Because the original debug_unreachable is abandoned and doesn't work correctly in modern Rust.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/206)
<!-- Reviewable:end -->
