### PR TITLE
Bump phf_generator generator version to 0.7.22

### DIFF
--- a/string-cache-codegen/Cargo.toml
+++ b/string-cache-codegen/Cargo.toml
@@ -14,7 +14,7 @@ path = "lib.rs"
 
 [dependencies]
 string_cache_shared = {path = "../shared", version = "0.3"}
-phf_generator = "0.7.15"
+phf_generator = "0.7.22"
 phf_shared = "0.7.4"
 proc-macro2 = "0.4"
 quote = "0.6"


### PR DESCRIPTION
This is useful for cargo minimal version builds. `phf_generator` in versions before 0.7.22 depended on rand 0.3 which itself depended on libc 0.1.1 that no longer compiles with the newest Rust version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/218)
<!-- Reviewable:end -->
