### PR TITLE
Move tests, benchmarks and codegen dependencies to sub-package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,7 @@ rust:
 os:
   - linux
 script:
-  - cargo build
-  - cargo test
-  - cargo test --features log-events
-  - "if [ $TRAVIS_RUST_VERSION = nightly ]; then cargo test --features unstable; fi"
-  - cargo test
-  - "cd string-cache-codegen/ && cargo build && cd .."
-  - "cd examples/event-log/ && cargo build && cd ../.."
-  - "cd examples/summarize-events/ && cargo build && cd ../.."
+  - cargo test --all
+  - cargo test --features log-events --all
+  - "if [ $TRAVIS_RUST_VERSION = nightly ]; then cargo test --features unstable --all; fi"
+  - cargo build --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ description = "A string interning library for Rust, developed as part of the Ser
 license = "MIT / Apache-2.0"
 repository = "https://github.com/servo/string-cache"
 documentation = "https://docs.rs/string_cache/"
-build = "build.rs"
 
 # Do not `exclude` ./string-cache-codegen because we want to include
 # ./string-cache-codegen/shared.rs, and `include` is a pain to use
@@ -35,9 +34,8 @@ phf_shared = "0.7.4"
 new_debug_unreachable = "1.0"
 string_cache_shared = {path = "./shared", version = "0.3"}
 
-[dev-dependencies]
-rand = "0.4"
-string_cache_codegen = { version = "0.4", path = "./string-cache-codegen" }
-
-[build-dependencies]
-string_cache_codegen = { version = "0.4", path = "./string-cache-codegen" }
+[workspace]
+members = [
+    "string-cache-codegen",
+    "integration-tests",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,6 @@ string_cache_shared = {path = "./shared", version = "0.3"}
 members = [
     "string-cache-codegen",
     "integration-tests",
+    "examples/event-log",
+    "examples/summarize-events"
 ]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "integration_tests"
+version = "0.0.1"
+authors = [ "The Servo Project Developers" ]
+build = "build.rs"
+publish = false
+
+[lib]
+doctest = false
+test = true
+
+[features]
+
+# Use unstable features to optimize space and time (memory and CPU usage).
+unstable = ["string_cache/unstable"]
+
+[dependencies]
+string_cache = { version = ">= 0.7.3, <= 9000", path = ".." }
+
+[dev-dependencies]
+rand = "0.4"
+string_cache_codegen = { version = "0.4", path = "../string-cache-codegen" }
+
+[build-dependencies]
+string_cache_codegen = { version = "0.4", path = "../string-cache-codegen" }

--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::path::Path;
 
 fn main() {
-    string_cache_codegen::AtomType::new("atom::tests::TestAtom", "test_atom!")
+    string_cache_codegen::AtomType::new("TestAtom", "test_atom!")
         .atoms(&[
             "a", "b", "address", "area", "body", "font-weight", "br", "html", "head", "id",
         ])

--- a/integration-tests/src/bench.rs
+++ b/integration-tests/src/bench.rs
@@ -26,8 +26,8 @@ Furthermore, a large part of the point of interning is to make strings small
 and cheap to move around, which isn't reflected in these tests.
 
 */
+use crate::TestAtom;
 
-use atom::tests::TestAtom;
 use test::{Bencher, black_box};
 
 // Just shorthand
@@ -35,14 +35,11 @@ fn mk(x: &str) -> TestAtom {
     TestAtom::from(x)
 }
 
-macro_rules! check_type (($name:ident, $x:expr, $p:pat) => (
+macro_rules! check_type (($name:ident, $x:expr) => (
     // NB: "cargo bench" does not run these!
     #[test]
     fn $name() {
-        match unsafe { $x.unpack() } {
-            $p => (),
-            _ => panic!("atom has wrong type"),
-        }
+        assert!($x, "atom has wrong type");
     }
 ));
 
@@ -62,12 +59,12 @@ macro_rules! bench_tiny_op (($name:ident, $op:ident, $ctor_x:expr, $ctor_y:expr)
 ));
 
 macro_rules! bench_one (
-    (x_static   $x:expr, $y:expr) => (check_type!(check_type_x, $x, Static(..)););
-    (x_inline   $x:expr, $y:expr) => (check_type!(check_type_x, $x, Inline(..)););
-    (x_dynamic  $x:expr, $y:expr) => (check_type!(check_type_x, $x, Dynamic(..)););
-    (y_static   $x:expr, $y:expr) => (check_type!(check_type_y, $y, Static(..)););
-    (y_inline   $x:expr, $y:expr) => (check_type!(check_type_y, $y, Inline(..)););
-    (y_dynamic  $x:expr, $y:expr) => (check_type!(check_type_y, $y, Dynamic(..)););
+    (x_static   $x:expr, $y:expr) => (check_type!(check_type_x, $x.is_static()););
+    (x_inline   $x:expr, $y:expr) => (check_type!(check_type_x, $x.is_inline()););
+    (x_dynamic  $x:expr, $y:expr) => (check_type!(check_type_x, $x.is_dynamic()););
+    (y_static   $x:expr, $y:expr) => (check_type!(check_type_y, $y.is_static()););
+    (y_inline   $x:expr, $y:expr) => (check_type!(check_type_y, $y.is_inline()););
+    (y_dynamic  $x:expr, $y:expr) => (check_type!(check_type_y, $y.is_dynamic()););
     (is_static  $x:expr, $y:expr) => (bench_one!(x_static  $x, $y); bench_one!(y_static  $x, $y););
     (is_inline  $x:expr, $y:expr) => (bench_one!(x_inline  $x, $y); bench_one!(y_inline  $x, $y););
     (is_dynamic $x:expr, $y:expr) => (bench_one!(x_dynamic $x, $y); bench_one!(y_dynamic $x, $y););
@@ -134,8 +131,7 @@ macro_rules! bench_all (
             use std::string::ToString;
             use std::iter::repeat;
 
-            use atom::tests::TestAtom;
-            use atom::UnpackedAtom::{Static, Inline, Dynamic};
+            use crate::TestAtom;
 
             use super::mk;
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,0 +1,276 @@
+// Copyright 2014 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![cfg(test)]
+
+#![deny(warnings)]
+#![allow(non_upper_case_globals)]
+
+#![cfg_attr(feature = "unstable", feature(test))]
+
+extern crate string_cache;
+
+#[cfg(feature = "unstable")] extern crate test;
+#[cfg(feature = "unstable")] extern crate rand;
+
+use std::thread;
+use string_cache::atom::StaticAtomSet;
+
+include!(concat!(env!("OUT_DIR"), "/test_atom.rs"));
+pub type Atom = TestAtom;
+
+#[test]
+fn test_as_slice() {
+    let s0 = Atom::from("");
+    assert!(s0.as_ref() == "");
+
+    let s1 = Atom::from("class");
+    assert!(s1.as_ref() == "class");
+
+    let i0 = Atom::from("blah");
+    assert!(i0.as_ref() == "blah");
+
+    let s0 = Atom::from("BLAH");
+    assert!(s0.as_ref() == "BLAH");
+
+    let d0 = Atom::from("zzzzzzzzzz");
+    assert!(d0.as_ref() == "zzzzzzzzzz");
+
+    let d1 = Atom::from("ZZZZZZZZZZ");
+    assert!(d1.as_ref() == "ZZZZZZZZZZ");
+}
+
+#[test]
+fn test_types() {
+    assert!(Atom::from("").is_static());
+    assert!(Atom::from("id").is_static());
+    assert!(Atom::from("body").is_static());
+    assert!(Atom::from("a").is_static());
+    assert!(Atom::from("c").is_inline());
+    assert!(Atom::from("zz").is_inline());
+    assert!(Atom::from("zzz").is_inline());
+    assert!(Atom::from("zzzz").is_inline());
+    assert!(Atom::from("zzzzz").is_inline());
+    assert!(Atom::from("zzzzzz").is_inline());
+    assert!(Atom::from("zzzzzzz").is_inline());
+    assert!(Atom::from("zzzzzzzz").is_dynamic());
+    assert!(Atom::from("zzzzzzzzzzzzz").is_dynamic());
+}
+
+#[test]
+fn test_equality() {
+    let s0 = Atom::from("fn");
+    let s1 = Atom::from("fn");
+    let s2 = Atom::from("loop");
+
+    let i0 = Atom::from("blah");
+    let i1 = Atom::from("blah");
+    let i2 = Atom::from("blah2");
+
+    let d0 = Atom::from("zzzzzzzz");
+    let d1 = Atom::from("zzzzzzzz");
+    let d2 = Atom::from("zzzzzzzzz");
+
+    assert!(s0 == s1);
+    assert!(s0 != s2);
+
+    assert!(i0 == i1);
+    assert!(i0 != i2);
+
+    assert!(d0 == d1);
+    assert!(d0 != d2);
+
+    assert!(s0 != i0);
+    assert!(s0 != d0);
+    assert!(i0 != d0);
+}
+
+#[test]
+fn default() {
+    assert_eq!(TestAtom::default(), test_atom!(""));
+    assert_eq!(&*TestAtom::default(), "");
+}
+
+#[test]
+fn ord() {
+    fn check(x: &str, y: &str) {
+        assert_eq!(x < y, Atom::from(x) < Atom::from(y));
+        assert_eq!(x.cmp(y), Atom::from(x).cmp(&Atom::from(y)));
+        assert_eq!(x.partial_cmp(y), Atom::from(x).partial_cmp(&Atom::from(y)));
+    }
+
+    check("a", "body");
+    check("asdf", "body");
+    check("zasdf", "body");
+    check("z", "body");
+
+    check("a", "bbbbb");
+    check("asdf", "bbbbb");
+    check("zasdf", "bbbbb");
+    check("z", "bbbbb");
+}
+
+#[test]
+fn clone() {
+    let s0 = Atom::from("fn");
+    let s1 = s0.clone();
+    let s2 = Atom::from("loop");
+
+    let i0 = Atom::from("blah");
+    let i1 = i0.clone();
+    let i2 = Atom::from("blah2");
+
+    let d0 = Atom::from("zzzzzzzz");
+    let d1 = d0.clone();
+    let d2 = Atom::from("zzzzzzzzz");
+
+    assert!(s0 == s1);
+    assert!(s0 != s2);
+
+    assert!(i0 == i1);
+    assert!(i0 != i2);
+
+    assert!(d0 == d1);
+    assert!(d0 != d2);
+
+    assert!(s0 != i0);
+    assert!(s0 != d0);
+    assert!(i0 != d0);
+}
+
+macro_rules! assert_eq_fmt (($fmt:expr, $x:expr, $y:expr) => ({
+    let x = $x;
+    let y = $y;
+    if x != y {
+        panic!("assertion failed: {} != {}",
+            format_args!($fmt, x),
+            format_args!($fmt, y));
+    }
+}));
+
+#[test]
+fn repr() {
+    fn check(s: &str, data: u64) {
+        assert_eq_fmt!("0x{:016X}", Atom::from(s).unsafe_data, data);
+    }
+
+    fn check_static(s: &str, x: Atom) {
+        assert_eq_fmt!("0x{:016X}", x.unsafe_data, Atom::from(s).unsafe_data);
+        assert_eq!(0x2, x.unsafe_data & 0xFFFF_FFFF);
+        // The index is unspecified by phf.
+        assert!((x.unsafe_data >> 32) <= TestAtomStaticSet::get().atoms.len() as u64);
+    }
+
+    // This test is here to make sure we don't change atom representation
+    // by accident.  It may need adjusting if there are changes to the
+    // static atom table, the tag values, etc.
+
+    // Static atoms
+    check_static("a",       test_atom!("a"));
+    check_static("address", test_atom!("address"));
+    check_static("area",    test_atom!("area"));
+
+    // Inline atoms
+    check("e",       0x0000_0000_0000_6511);
+    check("xyzzy",   0x0000_797A_7A79_7851);
+    check("xyzzy01", 0x3130_797A_7A79_7871);
+
+    // Dynamic atoms. This is a pointer so we can't verify every bit.
+    assert_eq!(0x00, Atom::from("a dynamic string").unsafe_data & 0xf);
+}
+
+#[test]
+fn test_threads() {
+    for _ in 0_u32..100 {
+        thread::spawn(move || {
+            let _ = Atom::from("a dynamic string");
+            let _ = Atom::from("another string");
+        });
+    }
+}
+
+#[test]
+fn atom_macro() {
+    assert_eq!(test_atom!("body"), Atom::from("body"));
+    assert_eq!(test_atom!("font-weight"), Atom::from("font-weight"));
+}
+
+#[test]
+fn match_atom() {
+    assert_eq!(2, match Atom::from("head") {
+        test_atom!("br") => 1,
+        test_atom!("html") | test_atom!("head") => 2,
+        _ => 3,
+    });
+
+    assert_eq!(3, match Atom::from("body") {
+        test_atom!("br") => 1,
+        test_atom!("html") | test_atom!("head") => 2,
+        _ => 3,
+    });
+
+    assert_eq!(3, match Atom::from("zzzzzz") {
+        test_atom!("br") => 1,
+        test_atom!("html") | test_atom!("head") => 2,
+        _ => 3,
+    });
+}
+
+#[test]
+fn ensure_deref() {
+    // Ensure we can Deref to a &str
+    let atom = Atom::from("foobar");
+    let _: &str = &atom;
+}
+
+#[test]
+fn ensure_as_ref() {
+    // Ensure we can as_ref to a &str
+    let atom = Atom::from("foobar");
+    let _: &str = atom.as_ref();
+}
+
+#[test]
+fn test_ascii_lowercase() {
+    assert_eq!(Atom::from("").to_ascii_lowercase(), Atom::from(""));
+    assert_eq!(Atom::from("aZ9").to_ascii_lowercase(), Atom::from("az9"));
+    assert_eq!(Atom::from("The Quick Brown Fox!").to_ascii_lowercase(), Atom::from("the quick brown fox!"));
+    assert_eq!(Atom::from("JE VAIS À PARIS").to_ascii_lowercase(), Atom::from("je vais À paris"));
+}
+
+#[test]
+fn test_ascii_uppercase() {
+    assert_eq!(Atom::from("").to_ascii_uppercase(), Atom::from(""));
+    assert_eq!(Atom::from("aZ9").to_ascii_uppercase(), Atom::from("AZ9"));
+    assert_eq!(Atom::from("The Quick Brown Fox!").to_ascii_uppercase(), Atom::from("THE QUICK BROWN FOX!"));
+    assert_eq!(Atom::from("Je vais à Paris").to_ascii_uppercase(), Atom::from("JE VAIS à PARIS"));
+}
+
+#[test]
+fn test_eq_ignore_ascii_case() {
+    assert!(Atom::from("").eq_ignore_ascii_case(&Atom::from("")));
+    assert!(Atom::from("aZ9").eq_ignore_ascii_case(&Atom::from("aZ9")));
+    assert!(Atom::from("aZ9").eq_ignore_ascii_case(&Atom::from("Az9")));
+    assert!(Atom::from("The Quick Brown Fox!").eq_ignore_ascii_case(&Atom::from("THE quick BROWN fox!")));
+    assert!(Atom::from("Je vais à Paris").eq_ignore_ascii_case(&Atom::from("je VAIS à PARIS")));
+    assert!(!Atom::from("").eq_ignore_ascii_case(&Atom::from("az9")));
+    assert!(!Atom::from("aZ9").eq_ignore_ascii_case(&Atom::from("")));
+    assert!(!Atom::from("aZ9").eq_ignore_ascii_case(&Atom::from("9Za")));
+    assert!(!Atom::from("The Quick Brown Fox!").eq_ignore_ascii_case(&Atom::from("THE quick BROWN fox!!")));
+    assert!(!Atom::from("Je vais à Paris").eq_ignore_ascii_case(&Atom::from("JE vais À paris")));
+}
+
+#[test]
+fn test_from_string() {
+    assert!(Atom::from("camembert".to_owned()) == Atom::from("camembert"));
+}
+
+#[cfg(all(test, feature = "unstable"))]
+#[path = "bench.rs"]
+mod bench;

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -118,7 +118,6 @@ impl StringCache {
             (value.hash & BUCKET_MASK) as usize
         };
 
-
         let mut current: &mut Option<Box<StringCacheEntry>> = &mut self.buckets[bucket_index];
 
         loop {
@@ -264,6 +263,30 @@ impl<Static: StaticAtomSet> Atom<Static> {
     #[inline(always)]
     unsafe fn unpack(&self) -> UnpackedAtom {
         UnpackedAtom::from_packed(self.unsafe_data)
+    }
+
+    /// Return true if this is a static Atom.
+    pub fn is_static(&self) -> bool {
+        match unsafe { self.unpack() } {
+            Static(..) => true,
+            _ => false
+        }
+    }
+
+    /// Return true if this is a dynamic Atom.
+    pub fn is_dynamic(&self) -> bool {
+        match unsafe { self.unpack() } {
+            Dynamic(..) => true,
+            _ => false
+        }
+    }
+
+    /// Return true if this is an inline Atom.
+    pub fn is_inline(&self) -> bool {
+        match unsafe { self.unpack() } {
+            Inline(..) => true,
+            _ => false
+        }
     }
 
     /// Get the hash of the string as it is stored in the set.
@@ -664,183 +687,13 @@ unsafe fn inline_orig_bytes<'a>(data: &'a u64) -> &'a [u8] {
     }
 }
 
+// Some minor tests of internal layout here. See ../integration-tests for much
+// more.
 #[cfg(test)]
-#[macro_use]
 mod tests {
     use std::mem;
-    use std::thread;
-    use super::{StaticAtomSet, StringCacheEntry};
-    use super::UnpackedAtom::{Dynamic, Inline, Static};
+    use super::{DefaultAtom, StringCacheEntry};
     use shared::ENTRY_ALIGNMENT;
-
-    include!(concat!(env!("OUT_DIR"), "/test_atom.rs"));
-    pub type Atom = TestAtom;
-
-    #[test]
-    fn test_as_slice() {
-        let s0 = Atom::from("");
-        assert!(s0.as_ref() == "");
-
-        let s1 = Atom::from("class");
-        assert!(s1.as_ref() == "class");
-
-        let i0 = Atom::from("blah");
-        assert!(i0.as_ref() == "blah");
-
-        let s0 = Atom::from("BLAH");
-        assert!(s0.as_ref() == "BLAH");
-
-        let d0 = Atom::from("zzzzzzzzzz");
-        assert!(d0.as_ref() == "zzzzzzzzzz");
-
-        let d1 = Atom::from("ZZZZZZZZZZ");
-        assert!(d1.as_ref() == "ZZZZZZZZZZ");
-    }
-
-    macro_rules! unpacks_to (($e:expr, $t:pat) => (
-        match unsafe { Atom::from($e).unpack() } {
-            $t => (),
-            _ => panic!("atom has wrong type"),
-        }
-    ));
-
-    #[test]
-    fn test_types() {
-        unpacks_to!("", Static(..));
-        unpacks_to!("id", Static(..));
-        unpacks_to!("body", Static(..));
-        unpacks_to!("c", Inline(..)); // "z" is a static atom
-        unpacks_to!("zz", Inline(..));
-        unpacks_to!("zzz", Inline(..));
-        unpacks_to!("zzzz", Inline(..));
-        unpacks_to!("zzzzz", Inline(..));
-        unpacks_to!("zzzzzz", Inline(..));
-        unpacks_to!("zzzzzzz", Inline(..));
-        unpacks_to!("zzzzzzzz", Dynamic(..));
-        unpacks_to!("zzzzzzzzzzzzz", Dynamic(..));
-    }
-
-    #[test]
-    fn test_equality() {
-        let s0 = Atom::from("fn");
-        let s1 = Atom::from("fn");
-        let s2 = Atom::from("loop");
-
-        let i0 = Atom::from("blah");
-        let i1 = Atom::from("blah");
-        let i2 = Atom::from("blah2");
-
-        let d0 = Atom::from("zzzzzzzz");
-        let d1 = Atom::from("zzzzzzzz");
-        let d2 = Atom::from("zzzzzzzzz");
-
-        assert!(s0 == s1);
-        assert!(s0 != s2);
-
-        assert!(i0 == i1);
-        assert!(i0 != i2);
-
-        assert!(d0 == d1);
-        assert!(d0 != d2);
-
-        assert!(s0 != i0);
-        assert!(s0 != d0);
-        assert!(i0 != d0);
-    }
-
-    #[test]
-    fn default() {
-        assert_eq!(TestAtom::default(), test_atom!(""));
-        assert_eq!(&*TestAtom::default(), "");
-    }
-
-    #[test]
-    fn ord() {
-        fn check(x: &str, y: &str) {
-            assert_eq!(x < y, Atom::from(x) < Atom::from(y));
-            assert_eq!(x.cmp(y), Atom::from(x).cmp(&Atom::from(y)));
-            assert_eq!(x.partial_cmp(y), Atom::from(x).partial_cmp(&Atom::from(y)));
-        }
-
-        check("a", "body");
-        check("asdf", "body");
-        check("zasdf", "body");
-        check("z", "body");
-
-        check("a", "bbbbb");
-        check("asdf", "bbbbb");
-        check("zasdf", "bbbbb");
-        check("z", "bbbbb");
-    }
-
-    #[test]
-    fn clone() {
-        let s0 = Atom::from("fn");
-        let s1 = s0.clone();
-        let s2 = Atom::from("loop");
-
-        let i0 = Atom::from("blah");
-        let i1 = i0.clone();
-        let i2 = Atom::from("blah2");
-
-        let d0 = Atom::from("zzzzzzzz");
-        let d1 = d0.clone();
-        let d2 = Atom::from("zzzzzzzzz");
-
-        assert!(s0 == s1);
-        assert!(s0 != s2);
-
-        assert!(i0 == i1);
-        assert!(i0 != i2);
-
-        assert!(d0 == d1);
-        assert!(d0 != d2);
-
-        assert!(s0 != i0);
-        assert!(s0 != d0);
-        assert!(i0 != d0);
-    }
-
-    macro_rules! assert_eq_fmt (($fmt:expr, $x:expr, $y:expr) => ({
-        let x = $x;
-        let y = $y;
-        if x != y {
-            panic!("assertion failed: {} != {}",
-                format_args!($fmt, x),
-                format_args!($fmt, y));
-        }
-    }));
-
-    #[test]
-    fn repr() {
-        fn check(s: &str, data: u64) {
-            assert_eq_fmt!("0x{:016X}", Atom::from(s).unsafe_data, data);
-        }
-
-        fn check_static(s: &str, x: Atom) {
-            assert_eq_fmt!("0x{:016X}", x.unsafe_data, Atom::from(s).unsafe_data);
-            assert_eq!(0x2, x.unsafe_data & 0xFFFF_FFFF);
-            // The index is unspecified by phf.
-            assert!((x.unsafe_data >> 32) <= TestAtomStaticSet::get().atoms.len() as u64);
-        }
-
-        // This test is here to make sure we don't change atom representation
-        // by accident.  It may need adjusting if there are changes to the
-        // static atom table, the tag values, etc.
-
-        // Static atoms
-        check_static("a",       test_atom!("a"));
-        check_static("address", test_atom!("address"));
-        check_static("area",    test_atom!("area"));
-
-        // Inline atoms
-        check("e",       0x0000_0000_0000_6511);
-        check("xyzzy",   0x0000_797A_7A79_7851);
-        check("xyzzy01", 0x3130_797A_7A79_7871);
-
-        // Dynamic atoms. This is a pointer so we can't verify every bit.
-        assert_eq!(0x00, Atom::from("a dynamic string").unsafe_data & 0xf);
-    }
 
     #[test]
     fn assert_sizes() {
@@ -852,104 +705,14 @@ mod tests {
         let compiler_uses_inline_drop_flags = mem::size_of::<EmptyWithDrop>() > 0;
 
         // Guard against accidental changes to the sizes of things.
-        assert_eq!(mem::size_of::<Atom>(),
+        assert_eq!(mem::size_of::<DefaultAtom>(),
                    if compiler_uses_inline_drop_flags { 16 } else { 8 });
         assert_eq!(mem::size_of::<super::StringCacheEntry>(),
                    8 + 4 * mem::size_of::<usize>());
     }
 
     #[test]
-    fn test_threads() {
-        for _ in 0_u32..100 {
-            thread::spawn(move || {
-                let _ = Atom::from("a dynamic string");
-                let _ = Atom::from("another string");
-            });
-        }
-    }
-
-    #[test]
-    fn atom_macro() {
-        assert_eq!(test_atom!("body"), Atom::from("body"));
-        assert_eq!(test_atom!("font-weight"), Atom::from("font-weight"));
-    }
-
-    #[test]
-    fn match_atom() {
-        assert_eq!(2, match Atom::from("head") {
-            test_atom!("br") => 1,
-            test_atom!("html") | test_atom!("head") => 2,
-            _ => 3,
-        });
-
-        assert_eq!(3, match Atom::from("body") {
-            test_atom!("br") => 1,
-            test_atom!("html") | test_atom!("head") => 2,
-            _ => 3,
-        });
-
-        assert_eq!(3, match Atom::from("zzzzzz") {
-            test_atom!("br") => 1,
-            test_atom!("html") | test_atom!("head") => 2,
-            _ => 3,
-        });
-    }
-
-    #[test]
-    fn ensure_deref() {
-        // Ensure we can Deref to a &str
-        let atom = Atom::from("foobar");
-        let _: &str = &atom;
-    }
-
-    #[test]
-    fn ensure_as_ref() {
-        // Ensure we can as_ref to a &str
-        let atom = Atom::from("foobar");
-        let _: &str = atom.as_ref();
-    }
-
-    #[test]
     fn string_cache_entry_alignment_is_sufficient() {
         assert!(mem::align_of::<StringCacheEntry>() >= ENTRY_ALIGNMENT);
     }
-
-    #[test]
-    fn test_ascii_lowercase() {
-        assert_eq!(Atom::from("").to_ascii_lowercase(), Atom::from(""));
-        assert_eq!(Atom::from("aZ9").to_ascii_lowercase(), Atom::from("az9"));
-        assert_eq!(Atom::from("The Quick Brown Fox!").to_ascii_lowercase(), Atom::from("the quick brown fox!"));
-        assert_eq!(Atom::from("JE VAIS À PARIS").to_ascii_lowercase(), Atom::from("je vais À paris"));
-    }
-
-    #[test]
-    fn test_ascii_uppercase() {
-        assert_eq!(Atom::from("").to_ascii_uppercase(), Atom::from(""));
-        assert_eq!(Atom::from("aZ9").to_ascii_uppercase(), Atom::from("AZ9"));
-        assert_eq!(Atom::from("The Quick Brown Fox!").to_ascii_uppercase(), Atom::from("THE QUICK BROWN FOX!"));
-        assert_eq!(Atom::from("Je vais à Paris").to_ascii_uppercase(), Atom::from("JE VAIS à PARIS"));
-    }
-
-    #[test]
-    fn test_eq_ignore_ascii_case() {
-        assert!(Atom::from("").eq_ignore_ascii_case(&Atom::from("")));
-        assert!(Atom::from("aZ9").eq_ignore_ascii_case(&Atom::from("aZ9")));
-        assert!(Atom::from("aZ9").eq_ignore_ascii_case(&Atom::from("Az9")));
-        assert!(Atom::from("The Quick Brown Fox!").eq_ignore_ascii_case(&Atom::from("THE quick BROWN fox!")));
-        assert!(Atom::from("Je vais à Paris").eq_ignore_ascii_case(&Atom::from("je VAIS à PARIS")));
-        assert!(!Atom::from("").eq_ignore_ascii_case(&Atom::from("az9")));
-        assert!(!Atom::from("aZ9").eq_ignore_ascii_case(&Atom::from("")));
-        assert!(!Atom::from("aZ9").eq_ignore_ascii_case(&Atom::from("9Za")));
-        assert!(!Atom::from("The Quick Brown Fox!").eq_ignore_ascii_case(&Atom::from("THE quick BROWN fox!!")));
-        assert!(!Atom::from("Je vais à Paris").eq_ignore_ascii_case(&Atom::from("JE vais À paris")));
-    }
-
-    #[test]
-    fn test_from_string() {
-        assert!(Atom::from("camembert".to_owned()) == Atom::from("camembert"));
-    }
 }
-
-#[cfg(all(test, feature = "unstable"))]
-#[path = "bench.rs"]
-mod bench;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! In `build.rs`:
 //!
-//! ```
+//! ```ignore
 //! extern crate string_cache_codegen;
 //!
 //! use std::env;
@@ -105,10 +105,7 @@
 #![crate_type = "rlib"]
 
 #![cfg_attr(test, deny(warnings))]
-#![cfg_attr(all(test, feature = "unstable"), feature(test))]
 
-#[cfg(all(test, feature = "unstable"))] extern crate test;
-#[cfg(all(test, feature = "unstable"))] extern crate rand;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate debug_unreachable;
 extern crate phf_shared;


### PR DESCRIPTION
Fixes #225 

This removes the codegen build dependency of the string_cache crate, thereby minimizing dep for users that don't need codegen.
    
To allow the now external integration tests and benchmarks to test the same things, public `Atom::is_(static|dynamic|inline) -> bool` methods were added.  

I don't see much downside to splitting the tests out in this way?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/226)
<!-- Reviewable:end -->
