### PR TITLE
Pin rustc version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: rust
 rust:
+  - 1.36.0
   - nightly
   - beta
   - stable


### PR DESCRIPTION
This ensures that we test against Rust 1.36 in CI on all builds. This is very helpful documentation for downstream maintainers, as it quickly helps us figure out what version of Rust is supported by the library, and highlights changes to the minimum supported version during code review.

Closes #228.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/string-cache/229)
<!-- Reviewable:end -->
