### PR TITLE
Make serde dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rust:
 os:
   - linux
 script:
+  - cargo build --no-default-features
   - cargo build
   - cargo test --all
   - "cd string-cache-codegen && cargo build && cd .."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,14 @@ edition = "2018"
 [lib]
 name = "string_cache"
 
+[features]
+serde_support = ["serde"]
+default = ["serde_support"]
+
 [dependencies]
 precomputed-hash = "0.1"
 lazy_static = "1"
-serde = "1"
+serde = { version = "1", optional = true }
 phf_shared = "0.8"
 new_debug_unreachable = "1.0"
 

--- a/src/trivial_impls.rs
+++ b/src/trivial_impls.rs
@@ -8,6 +8,7 @@
 // except according to those terms.
 
 use crate::{Atom, StaticAtomSet};
+#[cfg(feature = "serde_support")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 use std::fmt;
@@ -69,6 +70,7 @@ impl<Static: StaticAtomSet> AsRef<str> for Atom<Static> {
     }
 }
 
+#[cfg(feature = "serde_support")]
 impl<Static: StaticAtomSet> Serialize for Atom<Static> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -79,6 +81,7 @@ impl<Static: StaticAtomSet> Serialize for Atom<Static> {
     }
 }
 
+#[cfg(feature = "serde_support")]
 impl<'a, Static: StaticAtomSet> Deserialize<'a> for Atom<Static> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
This crate (and deps) takes around 8s to compile on my machine. I checked and this is mostly serde, and without it, a full rebuild takes only 0.5s (again, on my machine).

Many users of the crate will need serde, but some will not (e.g. I don't), and it's nice to get that compile time back for those that don't. It's on by default, for compatibility reasons, because default seems reasonable, and because I don't really care so long as I can disable it.

I've named the feature `serde_support` instead of just `serde` in case you ever need to enable other crates or dep feature based on this (but perhaps I'm wrong and this would be possible anyway).

I have tested locally, and added a CI smoke test to ensure it compiles without serde, but we don't run tests with out it (there are no serde-specific tests AFAICT, since the impls are indeed trivial, so the result would be the same anyway).