### PR TITLE
Add an Atom::try_static method

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -290,6 +290,12 @@ fn test_from_string() {
     assert!(Atom::from("camembert".to_owned()) == Atom::from("camembert"));
 }
 
+#[test]
+fn test_try_static() {
+    assert!(Atom::try_static("head").is_some());
+    assert!(Atom::try_static("not in the static table").is_none());
+}
+
 #[cfg(all(test, feature = "unstable"))]
 #[path = "bench.rs"]
 mod bench;


### PR DESCRIPTION
This methods returns a new static Atom, or None if the provided string is not present in the static table. This is an optimization when using this library to speed up matching against a large table of static atoms, as it allows to skip locking the global table and inserting the new string when the match is going to fail anyway.

I'm not too sure about the name of the method but nothing better comes to mind right now, and same goes for the specifics of the implementation (I moved the hash calculation to a private method to limit code duplication but it's only three lines so it's probably not that important, plus returning the Hashes in Result::Err seems dubious)