### PR TITLE
Update phf, rand dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = ["serde_support"]
 precomputed-hash = "0.1"
 lazy_static = "1"
 serde = { version = "1", optional = true }
-phf_shared = "0.8"
+phf_shared = "0.10"
 new_debug_unreachable = "1.0"
 
 [[test]]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -19,7 +19,7 @@ unstable = []
 string_cache = { version = "0.8", path = ".." }
 
 [dev-dependencies]
-rand = "0.7"
+rand = "0.8"
 string_cache_codegen = { version = "0.5", path = "../string-cache-codegen" }
 
 [build-dependencies]

--- a/string-cache-codegen/Cargo.toml
+++ b/string-cache-codegen/Cargo.toml
@@ -13,7 +13,7 @@ name = "string_cache_codegen"
 path = "lib.rs"
 
 [dependencies]
-phf_generator = "0.8"
-phf_shared = "0.8"
+phf_generator = "0.10"
+phf_shared = "0.10"
 proc-macro2 = "1"
 quote = "1"


### PR DESCRIPTION
This updates to the latest versions of the rand and phf crates. The real point is updating the transitive dependency on 'rand', to help keep build times under control in consumers of this library that are already using the newer version. 