### PR TITLE
Use a custom Visitor in Deserialize

### DIFF
--- a/src/trivial_impls.rs
+++ b/src/trivial_impls.rs
@@ -114,6 +114,6 @@ impl<'a, Static: StaticAtomSet> Deserialize<'a> for Atom<Static> {
             }
         }
 
-        deserializer.deserialize_string(AtomVisitor(PhantomData))
+        deserializer.deserialize_str(AtomVisitor(PhantomData))
     }
 }

--- a/src/trivial_impls.rs
+++ b/src/trivial_impls.rs
@@ -87,7 +87,33 @@ impl<'a, Static: StaticAtomSet> Deserialize<'a> for Atom<Static> {
     where
         D: Deserializer<'a>,
     {
-        let string: String = Deserialize::deserialize(deserializer)?;
-        Ok(Atom::from(string))
+        use serde::de;
+        use std::marker::PhantomData;
+
+        struct AtomVisitor<Static: StaticAtomSet>(PhantomData<Static>);
+
+        impl<'de, Static: StaticAtomSet> de::Visitor<'de> for AtomVisitor<Static> {
+            type Value = Atom<Static>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "an Atom")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Atom::from(v))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Atom::from(v))
+            }
+        }
+
+        deserializer.deserialize_string(AtomVisitor(PhantomData))
     }
 }


### PR DESCRIPTION
This PR implements a simple custom `de::Visitor` for `Atom`, which allows for deserializing without unnecessary round-trips through a `String`.