### PR TITLE
Update MSRV to 1.38.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.36.0, nightly, beta, stable]
+        rust: [1.38.0, nightly, beta, stable]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This is required by new versions of the `instant` crate, which `parking_lot` depends upon.