### PR TITLE
fix: bump parking_lot to 0.12 in order to not create wasm export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.40.0, nightly, beta, stable]
+        rust: [1.49.0, nightly, beta, stable]
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ lazy_static = "1.1.0"
 serde = { version = "1", optional = true }
 phf_shared = "0.10"
 new_debug_unreachable = "1.0.2"
-parking_lot = "0.11"
+parking_lot = "0.12"
 
 [[test]]
 name = "small-stack"


### PR DESCRIPTION
parking_lot 0.11 was using parking_lot_core 0.8 which was creating a wasm export when targeting wasm: https://github.com/Amanieu/parking_lot/issues/269

This bumps to parking_lot 0.12, which uses parking_lot_core 0.9 which doesn't have the issue where it creates the wasm export.