### PR TITLE
Replace lazy_static with once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["serde_support"]
 
 [dependencies]
 precomputed-hash = "0.1"
-lazy_static = "1.1.0"
+once_cell = "1.10.0"
 serde = { version = "1", optional = true }
 phf_shared = "0.10"
 new_debug_unreachable = "1.0.2"


### PR DESCRIPTION
Nowadays I think it's generally preferred to use `once_cell` over `lazy_static`.