### PR TITLE
Fix comment typo

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -105,7 +105,7 @@ impl<Static> Atom<Static> {
 }
 
 impl<Static: StaticAtomSet> Atom<Static> {
-    /// Return the internal repersentation. For testing.
+    /// Return the internal representation. For testing.
     #[doc(hidden)]
     pub fn unsafe_data(&self) -> u64 {
         self.unsafe_data.get()


### PR DESCRIPTION
Tiny nit. Fixes a misspelling in a comment.