### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -361,7 +361,6 @@ impl<Static: StaticAtomSet> Atom<Static> {
 
 #[inline(always)]
 fn inline_atom_slice(x: &NonZeroU64) -> &[u8] {
-    
         let x: *const NonZeroU64 = x;
         let mut data = x as *const u8;
         // All except the lowest byte, which is first in little-endian, last in big-endian.
@@ -369,13 +368,11 @@ fn inline_atom_slice(x: &NonZeroU64) -> &[u8] {
             data = unsafe { data.offset(1) };
         }
         let len = 7;
-        unsafe { slice::from_raw_parts(data, len) }
-    
+        unsafe { slice::from_raw_parts(data, len) }   
 }
 
 #[inline(always)]
-fn inline_atom_slice_mut(x: &mut u64) -> &mut [u8] {
-    
+fn inline_atom_slice_mut(x: &mut u64) -> &mut [u8] {   
         let x: *mut u64 = x;
         let mut data = x as *mut u8;
         // All except the lowest byte, which is first in little-endian, last in big-endian.
@@ -384,5 +381,4 @@ fn inline_atom_slice_mut(x: &mut u64) -> &mut [u8] {
         }
         let len = 7;
         unsafe { slice::from_raw_parts_mut(data, len) }
-    
 }

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -361,28 +361,28 @@ impl<Static: StaticAtomSet> Atom<Static> {
 
 #[inline(always)]
 fn inline_atom_slice(x: &NonZeroU64) -> &[u8] {
-    unsafe {
+    
         let x: *const NonZeroU64 = x;
         let mut data = x as *const u8;
         // All except the lowest byte, which is first in little-endian, last in big-endian.
         if cfg!(target_endian = "little") {
-            data = data.offset(1);
+            data = unsafe { data.offset(1) };
         }
         let len = 7;
-        slice::from_raw_parts(data, len)
-    }
+        unsafe { slice::from_raw_parts(data, len) }
+    
 }
 
 #[inline(always)]
 fn inline_atom_slice_mut(x: &mut u64) -> &mut [u8] {
-    unsafe {
+    
         let x: *mut u64 = x;
         let mut data = x as *mut u8;
         // All except the lowest byte, which is first in little-endian, last in big-endian.
         if cfg!(target_endian = "little") {
-            data = data.offset(1);
+            data = unsafe { data.offset(1) };
         }
         let len = 7;
-        slice::from_raw_parts_mut(data, len)
-    }
+        unsafe { slice::from_raw_parts_mut(data, len) }
+    
 }


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html