### PR TITLE
chore: 🤖 make `parking_lot` dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,15 @@ name = "string_cache"
 
 [features]
 serde_support = ["serde"]
-default = ["serde_support"]
-
+default = ["serde_support", "parking_lot_support"]
+parking_lot_support = ["parking_lot"]
 [dependencies]
 precomputed-hash = "0.1"
 once_cell = "1.10.0"
 serde = { version = "1", optional = true }
 phf_shared = "0.10"
 new_debug_unreachable = "1.0.2"
-parking_lot = "0.12"
+parking_lot = { version = "0.12", optional = true}
 
 [[test]]
 name = "small-stack"

--- a/src/dynamic_set.rs
+++ b/src/dynamic_set.rs
@@ -8,12 +8,15 @@
 // except according to those terms.
 
 use once_cell::sync::Lazy;
+#[cfg(feature = "parking_lot_support")]
 use parking_lot::Mutex;
 use std::borrow::Cow;
 use std::mem;
 use std::ptr::NonNull;
 use std::sync::atomic::AtomicIsize;
 use std::sync::atomic::Ordering::SeqCst;
+#[cfg(not(feature = "parking_lot_support"))]
+use std::sync::Mutex;
 
 const NB_BUCKETS: usize = 1 << 12; // 4096
 const BUCKET_MASK: u32 = (1 << 12) - 1;


### PR DESCRIPTION
## Summary
`parking_lot` is not always the best choice after rust stable 1.62 https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html#thinner-faster-mutexes-on-linux
1. Make `parking_lot` an optional dependency
2. Adding a new feature `parking_lot_support` to let user enable the optional dependency `parking_lot`
3. Adding the feature `parking_lot_support` to the default_features list to avoid breaking changes.