### PR TITLE
feat: use bucket mutex instead of global mutex for dynamic set

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -200,8 +200,7 @@ impl<'a, Static: StaticAtomSet> From<Cow<'a, str>> for Atom<Static> {
                     phantom: PhantomData,
                 }
             } else {
-                let ptr: std::ptr::NonNull<Entry> =
-                    DYNAMIC_SET.lock().insert(string_to_add, hash.g);
+                let ptr: std::ptr::NonNull<Entry> = DYNAMIC_SET.insert(string_to_add, hash.g);
                 let data = ptr.as_ptr() as u64;
                 debug_assert!(0 == data & TAG_MASK);
                 Atom {
@@ -237,9 +236,7 @@ impl<Static> Drop for Atom<Static> {
 
         // Out of line to guide inlining.
         fn drop_slow<Static>(this: &mut Atom<Static>) {
-            DYNAMIC_SET
-                .lock()
-                .remove(this.unsafe_data.get() as *mut Entry);
+            DYNAMIC_SET.remove(this.unsafe_data.get() as *mut Entry);
         }
     }
 }


### PR DESCRIPTION
Background:

I'm working a concurrent program using [swc](https://github.com/swc-project/swc) to parse files in parallel. [swc](https://github.com/swc-project/swc) uses `string-cache`.

I have found the global mutex in the dynamic set being the major performance bottleneck for our application. Using instruments as the profiler, we can see that `string-cache` contributes to 11.4% (9.6s) of the time:

![image](https://user-images.githubusercontent.com/1430279/219409337-d720b2a0-f735-4906-9ab3-345046c0a9c0.png)

By switch to a a bucket level mutex (this PR), `string-cache` drops to 1.6% (1.04s) of the time: 

![image](https://user-images.githubusercontent.com/1430279/219410109-6418e244-1fe3-4c03-8bff-a3c2e213c3e4.png)

----

For this PR, can I kindly ask for a code review even if this PR cannot be merged due to any kind of circumstances, so I can safely patch my application with a fork, or help me polish this so everyone using swc can benefit from this PR.

Thank you all in advance. 🍻 
