### PR TITLE
Revert trivial impl of Borrow<str> for Atom

### DIFF
--- a/src/trivial_impls.rs
+++ b/src/trivial_impls.rs
@@ -70,12 +70,6 @@ impl<Static: StaticAtomSet> AsRef<str> for Atom<Static> {
     }
 }
 
-impl<Static: StaticAtomSet> Borrow<str> for Atom<Static> {
-    fn borrow(&self) -> &str {
-        self
-    }
-}
-
 #[cfg(feature = "serde_support")]
 impl<Static: StaticAtomSet> Serialize for Atom<Static> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/trivial_impls.rs
+++ b/src/trivial_impls.rs
@@ -10,7 +10,7 @@
 use crate::{Atom, StaticAtomSet};
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 use std::fmt;
 
 impl<Static: StaticAtomSet> ::precomputed_hash::PrecomputedHash for Atom<Static> {


### PR DESCRIPTION
#266 caused a breaking change (see #271) in 0.8.5 (which was yanked).
This PR fixes #271 / will allow publishing new versions (so #268 can make it out).


I've just started learning Rust, haven't been able to 100% wrap my head around the issue.

The breaking change manifesting in the "browserlist-rs" crate:
```rust
error[E0283]: type annotations needed
  --> {.. snip ..}\browserslist-rs-0.12.3\src\data\caniuse.rs:91:35
   |
91 |     let chrome = CANIUSE_BROWSERS.get(&"chrome".into()).unwrap();
   |                                   ^^^ ---------------- type must be known at this point
   |                                   |
   |                                   cannot infer type of the type parameter `Q` declared on the associated function `get`
   |
   = note: multiple `impl`s satisfying `Atom<BrowserNameAtomStaticSet>: Borrow<_>` found in the following crates: `core`, `string_cache`:
           - impl<Static> Borrow<str> for Atom<Static>
             where Static: StaticAtomSet;
           - impl<T> Borrow<T> for T
             where T: ?Sized;
note: required by a bound in `AHashMap::<K, V, S>::get`
  --> {.. snip ..}\ahash-0.7.6\src\hash_map.rs:81:12
   |
81 |         K: Borrow<Q>,
   |            ^^^^^^^^^ required by this bound in `AHashMap::<K, V, S>::get`
help: consider specifying the generic argument
   |
91 |     let chrome = CANIUSE_BROWSERS.get::<Q>(&"chrome".into()).unwrap();
   |                                      +++++
```

`CANIUSE_BROWSERS` is a
```rust
AHashMap<BrowserNameAtom, BrowserStat>
```

where `BrowserNameAtom` is an Atom generated with `string_cache_codegen`.

The signature of the `get` function:
```rust
pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
    where
        K: Borrow<Q>,
        Q: Hash + Eq,
    {
        self.0.get(k)
    }
```

`K` is the generic key type for the hash map.
This is the exact same signature as the std lib HashMap, to which it delegates.


When I debug 0.8.4 usage locally, the `From` that gets used for the `into()` is
```rust
impl<'a, Static: StaticAtomSet> From<&'a str> for Atom<Static> {
    #[inline]
    fn from(string_to_add: &str) -> Self {
        Atom::from(Cow::Borrowed(string_to_add))
    }
}
```

It isn't clear to me how the `Borrow<str>` impl that was added "competes" with the std lib's implementation here.
It doesn't seem relevant?
