### PR TITLE
Publish 0.8.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "string_cache"
-version = "0.8.5"  # Also update README.md when making a semver-breaking change
+version = "0.8.6"  # Also update README.md when making a semver-breaking change
 authors = [ "The Servo Project Developers" ]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The breaking change was reverted in #272.