### PR TITLE
test: add common dependents' usage

### DIFF
--- a/integration-tests/src/common-usage.rs
+++ b/integration-tests/src/common-usage.rs
@@ -1,0 +1,19 @@
+/// Test common usage by popular dependents (html5ever, lalrpop, browserlists-rs), to ensure no API-surface breaking changes
+/// Created after https://github.com/servo/string-cache/issues/271
+use std::collections::HashMap;
+
+use crate::Atom;
+use crate::TestAtom;
+
+#[test]
+fn usage_with_hashmap() {
+    let mut map: HashMap<TestAtom, i32> = HashMap::new();
+
+    map.insert(test_atom!("area"), 1);
+    map.insert("str_into".into(), 2);
+    map.insert("atom_from".into(), 3);
+
+    assert_eq!(map.get(&"area".into()).unwrap(), &1);
+    assert_eq!(map.get(&"str_into".into()).unwrap(), &2);
+    assert_eq!(map.get(&Atom::from("atom_from")).unwrap(), &3);
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -296,6 +296,10 @@ fn test_try_static() {
     assert!(Atom::try_static("not in the static table").is_none());
 }
 
+#[cfg(test)]
+#[path = "common-usage.rs"]
+mod common_usage;
+
 #[cfg(all(test, feature = "unstable"))]
 #[path = "bench.rs"]
 mod bench;


### PR DESCRIPTION
As a response to #271, added tests with common usage.

I modified the project structure, so I could make use of the canonical (according to [the docs](https://doc.rust-lang.org/book/ch11-03-test-organization.html)) "external tests" support.
I'm not familiar with the nitty gritty and ramifications of this change, so absolutely looking for guidance/advice/instructions.

Concerns I'm aware of:
1. Integration tests can't have their own `build.rs`, so I moved it to be under the main crate. Does it matter that it'll run with `cargo build` now, where previously it would only run with `cargo test`
2. The `bench.rs` is apparently only supported in nightly? It didn't run with `cargo test`. Is it in use at all? How can I make sure that it runs properly under the new structure (with the same command that would run it previously)?