### PR TITLE
Faster deref of inline atoms

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -254,8 +254,9 @@ impl<Static: StaticAtomSet> ops::Deref for Atom<Static> {
                 }
                 INLINE_TAG => {
                     let len = (self.unsafe_data() & LEN_MASK) >> LEN_OFFSET;
+                    debug_assert!(len as usize <= MAX_INLINE_LEN);
                     let src = inline_atom_slice(&self.unsafe_data);
-                    str::from_utf8_unchecked(&src[..(len as usize)])
+                    str::from_utf8_unchecked(src.get_unchecked(..(len as usize)))
                 }
                 STATIC_TAG => Static::get().atoms[self.static_index() as usize],
                 _ => debug_unreachable!(),


### PR DESCRIPTION
Deref of an atom (e.g. `atom.to_string()`) which stores the string inline performs slicing with `&src[..len]`. `len` is guaranteed to be within bounds, as an inline atom is always 7 bytes or less, so this can be substituted with `src.get_unchecked(..len)`.

Removing this bounds check improves performance of deref-ing an inline atom by approx 30%.

There's a lot of noise in the benchmarks, but it also seems to slightly improve performance of deref-ing static and dynamic atoms too, presumably because it reduces the size of the `deref()` function.

NB There's no gain to making the same change in `From<Cow<'a, str>> for Atom<Static>` because the compiler already deduces no bounds check is required due to the `if len <= MAX_INLINE_LEN` conditional.