### PR TITLE
Prefer inline representation over static

### DIFF
--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -9,6 +9,7 @@ fn main() {
             "a",
             "b",
             "address",
+            "defaults",
             "area",
             "body",
             "font-weight",

--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -17,6 +17,9 @@ fn main() {
             "html",
             "head",
             "id",
+            "❤",
+            "❤💯",
+            "❤💯❤💯",
         ])
         .write_to_file(&Path::new(&env::var("OUT_DIR").unwrap()).join("test_atom.rs"))
         .unwrap()

--- a/integration-tests/src/bench.rs
+++ b/integration-tests/src/bench.rs
@@ -153,7 +153,7 @@ bench_all!([eq ne lt clone_string]
     for longer_string = super::longer_dynamic_a, super::longer_dynamic_b);
 
 bench_all!([eq ne intern as_ref clone is_static lt]
-    for static_atom = test_atom!("a"), test_atom!("b"));
+    for static_atom = test_atom!("defaults"), test_atom!("font-weight"));
 
 bench_all!([intern as_ref clone is_inline]
     for short_inline_atom = mk("e"), mk("f"));
@@ -168,13 +168,13 @@ bench_all!([eq ne intern as_ref clone is_dynamic lt]
     for longer_dynamic_atom = mk(super::longer_dynamic_a), mk(super::longer_dynamic_b));
 
 bench_all!([intern as_ref clone is_static]
-    for static_at_runtime = mk("a"), mk("b"));
+    for static_at_runtime = mk("defaults"), mk("font-weight"));
 
 bench_all!([ne lt x_static y_inline]
-    for static_vs_inline  = test_atom!("a"), mk("f"));
+    for static_vs_inline  = test_atom!("defaults"), mk("f"));
 
 bench_all!([ne lt x_static y_dynamic]
-    for static_vs_dynamic = test_atom!("a"), mk(super::longer_dynamic_b));
+    for static_vs_dynamic = test_atom!("defaults"), mk(super::longer_dynamic_b));
 
 bench_all!([ne lt x_inline y_dynamic]
     for inline_vs_dynamic = mk("e"), mk(super::longer_dynamic_b));

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -47,10 +47,10 @@ fn test_types() {
     assert!(Atom::from("").is_static());
     assert!(Atom::from("defaults").is_static());
     assert!(Atom::from("font-weight").is_static());
-    assert!(Atom::from("id").is_static());
-    assert!(Atom::from("body").is_static());
-    assert!(Atom::from("a").is_static());
-    assert!(Atom::from("address").is_static());
+    assert!(Atom::from("id").is_inline());
+    assert!(Atom::from("body").is_inline());
+    assert!(Atom::from("a").is_inline());
+    assert!(Atom::from("address").is_inline());
     assert!(Atom::from("c").is_inline());
     assert!(Atom::from("zz").is_inline());
     assert!(Atom::from("zzz").is_inline());
@@ -173,11 +173,11 @@ fn repr() {
     // Static atoms
     check_static("defaults", test_atom!("defaults"));
     check_static("font-weight", test_atom!("font-weight"));
-    check_static("a", test_atom!("a"));
-    check_static("address", test_atom!("address"));
-    check_static("area", test_atom!("area"));
 
     // Inline atoms
+    check("a", 0x0000_0000_0000_6111);
+    check("address", 0x7373_6572_6464_6171);
+    check("area", 0x0000_0061_6572_6141);
     check("e", 0x0000_0000_0000_6511);
     check("xyzzy", 0x0000_797A_7A79_7851);
     check("xyzzy01", 0x3130_797A_7A79_7871);
@@ -201,7 +201,10 @@ fn atom_macro() {
     assert_eq!(test_atom!("a"), Atom::from("a"));
     assert_eq!(test_atom!("body"), Atom::from("body"));
     assert_eq!(test_atom!("address"), Atom::from("address"));
+    assert_eq!(test_atom!("❤"), Atom::from("❤"));
+    assert_eq!(test_atom!("❤💯"), Atom::from("❤💯"));
     assert_eq!(test_atom!("font-weight"), Atom::from("font-weight"));
+    assert_eq!(test_atom!("❤💯❤💯"), Atom::from("❤💯❤💯"));
 }
 
 #[test]
@@ -300,7 +303,7 @@ fn test_from_string() {
 #[test]
 fn test_try_static() {
     assert!(Atom::try_static("defaults").is_some());
-    assert!(Atom::try_static("head").is_some());
+    assert!(Atom::try_static("head").is_none());
     assert!(Atom::try_static("not in the static table").is_none());
 }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -45,9 +45,12 @@ fn test_as_slice() {
 #[test]
 fn test_types() {
     assert!(Atom::from("").is_static());
+    assert!(Atom::from("defaults").is_static());
+    assert!(Atom::from("font-weight").is_static());
     assert!(Atom::from("id").is_static());
     assert!(Atom::from("body").is_static());
     assert!(Atom::from("a").is_static());
+    assert!(Atom::from("address").is_static());
     assert!(Atom::from("c").is_inline());
     assert!(Atom::from("zz").is_inline());
     assert!(Atom::from("zzz").is_inline());
@@ -168,6 +171,8 @@ fn repr() {
     // static atom table, the tag values, etc.
 
     // Static atoms
+    check_static("defaults", test_atom!("defaults"));
+    check_static("font-weight", test_atom!("font-weight"));
     check_static("a", test_atom!("a"));
     check_static("address", test_atom!("address"));
     check_static("area", test_atom!("area"));
@@ -193,7 +198,9 @@ fn test_threads() {
 
 #[test]
 fn atom_macro() {
+    assert_eq!(test_atom!("a"), Atom::from("a"));
     assert_eq!(test_atom!("body"), Atom::from("body"));
+    assert_eq!(test_atom!("address"), Atom::from("address"));
     assert_eq!(test_atom!("font-weight"), Atom::from("font-weight"));
 }
 
@@ -292,6 +299,7 @@ fn test_from_string() {
 
 #[test]
 fn test_try_static() {
+    assert!(Atom::try_static("defaults").is_some());
     assert!(Atom::try_static("head").is_some());
     assert!(Atom::try_static("not in the static table").is_none());
 }

--- a/string-cache-codegen/lib.rs
+++ b/string-cache-codegen/lib.rs
@@ -187,11 +187,19 @@ impl AtomType {
         // which would cause divisions by zero in rust-phf.
         self.atoms.insert(String::new());
 
-        let atoms: Vec<&str> = self.atoms.iter().map(|s| &**s).collect();
-        let hash_state = phf_generator::generate_hash(&atoms);
+        // Strings over 7 bytes + empty string added to static set.
+        // Otherwise stored inline.
+        let (static_strs, inline_strs): (Vec<_>, Vec<_>) = self
+            .atoms
+            .iter()
+            .map(String::as_str)
+            .partition(|s| s.len() > 7 || s.is_empty());
+
+        // Static strings
+        let hash_state = phf_generator::generate_hash(&static_strs);
         let phf_generator::HashState { key, disps, map } = hash_state;
         let (disps0, disps1): (Vec<_>, Vec<_>) = disps.into_iter().unzip();
-        let atoms: Vec<&str> = map.iter().map(|&idx| atoms[idx]).collect();
+        let atoms: Vec<&str> = map.iter().map(|&idx| static_strs[idx]).collect();
         let empty_string_index = atoms.iter().position(|s| s.is_empty()).unwrap() as u32;
         let indices = 0..atoms.len() as u32;
 
@@ -228,16 +236,33 @@ impl AtomType {
         let macro_name = new_term(&*self.macro_name);
         let module = module.parse::<proc_macro2::TokenStream>().unwrap();
         let atom_prefix = format!("ATOM_{}_", type_name.to_string().to_uppercase());
-        let const_names: Vec<_> = atoms
+        let new_const_name = |atom: &str| {
+            let mut name = atom_prefix.clone();
+            for c in atom.chars() {
+                name.push_str(&format!("_{:02X}", c as u32))
+            }
+            new_term(&name)
+        };
+        let const_names: Vec<_> = atoms.iter().copied().map(new_const_name).collect();
+
+        // Inline strings
+        let (inline_const_names, inline_values_and_lengths): (Vec<_>, Vec<_>) = inline_strs
             .iter()
-            .map(|atom| {
-                let mut name = atom_prefix.clone();
-                for c in atom.chars() {
-                    name.push_str(&format!("_{:02X}", c as u32))
+            .map(|s| {
+                let const_name = new_const_name(s);
+
+                let mut value = 0u64;
+                for (index, c) in s.bytes().enumerate() {
+                    value = value | ((c as u64) << (index * 8 + 8));
                 }
-                new_term(&name)
+
+                let len = s.len() as u8;
+
+                (const_name, (value, len))
             })
-            .collect();
+            .unzip();
+        let (inline_values, inline_lengths): (Vec<_>, Vec<_>) =
+            inline_values_and_lengths.into_iter().unzip();
 
         quote! {
             #atom_doc
@@ -265,12 +290,18 @@ impl AtomType {
             #(
                 pub const #const_names: #type_name = #type_name::pack_static(#indices);
             )*
+            #(
+                pub const #inline_const_names: #type_name = #type_name::pack_inline(#inline_values, #inline_lengths);
+            )*
 
             #macro_doc
             #[macro_export]
             macro_rules! #macro_name {
                 #(
                     (#atoms) => { #module::#const_names };
+                )*
+                #(
+                    (#inline_strs) => { #module::#inline_const_names };
                 )*
             }
         }


### PR DESCRIPTION
As mentioned in #276, current behavior is that short strings can be stored as static strings or inline. This adds an overhead for interning short strings, as they need to be hashed and compared to possible matches in the static set.

This PR changes the behavior to always store strings of 7 bytes or less inline.

This greatly improves the performance of interning short strings - approx 250% speedup, depending on length of the string.

The benchmarks in this repo show no apparent negative effect on any other operations (though there's a lot of noise in the benchmarks).

This PR does not involve any breaking changes.

Even though interning short static atoms is very fast anyway, I imagine this change will translate to a significant real-world performance improvement for some use cases. For example, [SWC](https://github.com/swc-project/swc) uses string-cache when parsing Javascript which typically includes a lot of short variable names and tokens, especially in minified code e.g. `for (let i = 0; i < len; i++)`.

### Notes on implementation

* The empty string is still stored in static set. This is slightly non-optimal, but avoids a breaking change (`StaticAtomSet::empty_string_index` would need to be removed otherwise).
* Strings <= 7 bytes can still be passed to the codegen but it generates `pack_inline()` calls in place of `pack_static()` to generate inline atoms at compile time.
* Benchmarks needed to be altered to use longer strings when benchmarking static atoms. Benchmark changes are in a separate commit to allow comparing the benchmarks before and after the substantive change.
* This PR also includes the changes in #277. Without this, this PR produced a performance degradation deref-ing short strings as inline was not as performant as static.