### PR TITLE
Update phf to 0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.56.0, nightly, beta, stable]
+        rust: [1.60.0, nightly, beta, stable]
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = ["serde_support"]
 precomputed-hash = "0.1"
 once_cell = "1.10.0"
 serde = { version = "1", optional = true }
-phf_shared = "0.10"
+phf_shared = "0.11"
 new_debug_unreachable = "1.0.2"
 parking_lot = "0.12"
 

--- a/string-cache-codegen/Cargo.toml
+++ b/string-cache-codegen/Cargo.toml
@@ -13,7 +13,7 @@ name = "string_cache_codegen"
 path = "lib.rs"
 
 [dependencies]
-phf_generator = "0.10"
-phf_shared = "0.10"
+phf_generator = "0.11"
+phf_shared = "0.11"
 proc-macro2 = "1"
 quote = "1"


### PR DESCRIPTION
phf bumped their MSRV to 1.60 https://github.com/rust-phf/rust-phf/compare/v0.10.1...v0.11.0 . I couldn't find a MSRV policy for this crate to know if that's acceptable or not.