### PR TITLE
Update MSRV to 1.61.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.60.0, nightly, beta, stable]
+        rust: [1.61.0, nightly, beta, stable]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This is required by the latest version of syn, which is a dependency. Our CI is broken until we merge this.