### PR TITLE
Implement `MallocSizeOf` for `Atom`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           cargo build --no-default-features
           cargo build
+          cargo build --features malloc_size_of
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "string_cache"
-version = "0.8.8"  # Also update README.md when making a semver-breaking change
+version = "0.8.9"  # Also update README.md when making a semver-breaking change
 authors = ["The Servo Project Developers"]
 description = "A string interning library for Rust, developed as part of the Servo project."
 license = "MIT OR Apache-2.0"
@@ -25,6 +25,7 @@ default = ["serde_support"]
 [dependencies]
 precomputed-hash = "0.1"
 serde = { version = "1", optional = true }
+malloc_size_of = { version = "0.1", default-features = false, optional = true }
 phf_shared = "0.11"
 new_debug_unreachable = "1.0.2"
 parking_lot = "0.12"

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -82,6 +82,15 @@ pub struct Atom<Static> {
     phantom: PhantomData<Static>,
 }
 
+// This isn't really correct as the Atoms can technically take up space. But I guess it's ok
+// as it is possible to measure the size of the atom set separately/
+#[cfg(feature = "malloc_size_of")]
+impl<Static: StaticAtomSet> malloc_size_of::MallocSizeOf for Atom<Static> {
+    fn size_of(&self, _ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+        0
+    }
+}
+
 // FIXME: bound removed from the struct definition before of this error for pack_static:
 // "error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable"
 // https://github.com/rust-lang/rust/issues/57563


### PR DESCRIPTION
Now that [malloc_size_of](https://github.com/servo/malloc_size_of) is published to crates.io we are moving the trait implementations of [MallocSizeOf](https://docs.rs/malloc_size_of/latest/malloc_size_of/trait.MallocSizeOf.html) and related traits into the crates that define the types. This will avoid the situation where depending on `malloc_size_of` pulls in a large number of dependencies.

This PR adds the implementation of `MallocSizeOf` to the `string-cache` crate.