### PR TITLE
Expose a method to return the memory usage of all dynamic atoms.

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -82,8 +82,8 @@ pub struct Atom<Static> {
     phantom: PhantomData<Static>,
 }
 
-// This isn't really correct as the Atoms can technically take up space. But I guess it's ok
-// as it is possible to measure the size of the atom set separately/
+/// Static and inline atoms don’t have any allocated space. Dynamic atoms do but
+/// are accounted for by [`malloc_size_of_dynamic_set`][crate::malloc_size_of_dynamic_set].
 #[cfg(feature = "malloc_size_of")]
 impl<Static: StaticAtomSet> malloc_size_of::MallocSizeOf for Atom<Static> {
     fn size_of(&self, _ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {

--- a/src/dynamic_set.rs
+++ b/src/dynamic_set.rs
@@ -135,3 +135,26 @@ impl Set {
         }
     }
 }
+
+#[cfg(feature = "malloc_size_of")]
+pub fn malloc_size_of_dynamic_set(ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+    let mut sum = 0;
+    for bucket in &dynamic_set().buckets {
+        let guard = bucket.lock();
+        let mut next: Option<NonNull<Entry>> = *guard;
+        while let Some(ptr) = next {
+            // We would use `<Box<Entry> as malloc_size_of::MallocSizeOf>` here,
+            // but we don’t have `&Box<Entry>` only `NonNull<Entry>`.
+            // SAFETY: `ptr` is a valid heap-allocated pointer
+            sum += unsafe { ops.malloc_size_of::<Entry>(ptr.as_ptr()) };
+
+            // SAFETY: `ptr` is a valid pointer
+            let entry = unsafe { ptr.as_ref() };
+            sum += <Box<str> as malloc_size_of::MallocSizeOf>::size_of(&entry.string, ops);
+
+            // SAFETY: `UnsafeCell` is safe to access since we’re holding the `Mutex`
+            next = unsafe { *entry.next_in_bucket.get() };
+        }
+    }
+    sum
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,8 @@ mod static_sets;
 mod trivial_impls;
 
 pub use atom::Atom;
+#[cfg(feature = "malloc_size_of")]
+pub use dynamic_set::malloc_size_of_dynamic_set;
 pub use static_sets::{EmptyStaticAtomSet, PhfStrSet, StaticAtomSet};
 
 /// Use this if you don’t care about static atoms.


### PR DESCRIPTION
We need to perform a manual calculation because https://github.com/bholley/malloc_size_of_derive/ does not contain a MallocSizeOf implementation for `[...]`.