### PR TITLE
Make macros accept idents where atom value is a valid ident

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -19,7 +19,7 @@ unstable = []
 string_cache = { version = "0.9", path = ".." }
 
 [dev-dependencies]
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 string_cache_codegen = { version = "0.6", path = "../string-cache-codegen" }
 
 [build-dependencies]


### PR DESCRIPTION
This means that `local_name!(html)` will work as well as `local_name!("html")`.
If the atom value is something like `foo-bar` then `local_name!("foo-bar")` will work but `local_name!(foo-bar)` wont because `foo-bar` is not a valid `ident`.