### PR TITLE
Bump version of string-cache-codegen to v0.6.1

### DIFF
--- a/string-cache-codegen/Cargo.toml
+++ b/string-cache-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "string_cache_codegen"
-version = "0.6.0"  # Also update ../README.md when making a semver-breaking change
+version = "0.6.1"  # Also update ../README.md when making a semver-breaking change
 authors = [ "The Servo Project Developers" ]
 description = "A codegen library for string-cache, developed as part of the Servo project."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the version of `string-cache-codegen` so that we can put out a release that includes 533b64e132ec65a616317d2607f536da024d19a9 (after merging this PR we should also publish a release to crates.io).

Required for https://github.com/servo/html5ever/pull/640

