### PR TITLE
Fix Reference Count Overflow (Use-After-Free) in Atom::clone

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -248,7 +248,11 @@ impl<Static: StaticAtomSet> Clone for Atom<Static> {
     fn clone(&self) -> Self {
         if self.tag() == DYNAMIC_TAG {
             let entry = self.unsafe_data.get() as *const Entry;
-            unsafe { &*entry }.ref_count.fetch_add(1, SeqCst);
+            // SAFETY: `self` is a valid Atom, meaning its `unsafe_data` points to a live `Entry`
+            // kept alive by `self`'s reference count. We can safely dereference it.
+            if unsafe { &*entry }.ref_count.fetch_add(1, SeqCst) == std::isize::MAX {
+                std::process::abort();
+            }
         }
         Atom { ..*self }
     }


### PR DESCRIPTION
This PR adds a safeguard against Reference Count Overflow in `Atom::clone`.

If an `Atom`'s reference count exceeds `isize::MAX`, it will now deterministically abort the process (`std::process::abort()`) rather than wrapping around to a negative number and risking a subsequent Use-After-Free vulnerability.

Despite being unlikely to occur in practice, the fix should be easy and without real tradeoffs.

Fixes #299 