### PR TITLE
Run Miri and Clippy on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,18 @@ jobs:
         run: |
           rustup component add miri
           cargo miri setup
+          cargo miri setup --target i686-unknown-linux-gnu
+          cargo miri setup --target s390x-unknown-linux-gnu
       - name: Run Miri
         if: ${{ matrix.rust == 'nightly' }}
         # TODO: run without permissive provenance: https://github.com/servo/string-cache/issues/264
         run: MIRIFLAGS=-Zmiri-permissive-provenance cargo miri test --workspace
+      - name: Run Miri on 32-bit
+        if: ${{ matrix.rust == 'nightly' }}
+        run: MIRIFLAGS=-Zmiri-permissive-provenance cargo miri test --workspace --target i686-unknown-linux-gnu
+      - name: Run Miri on big-endian
+        if: ${{ matrix.rust == 'nightly' }}
+        run: MIRIFLAGS=-Zmiri-permissive-provenance cargo miri test --workspace --target s390x-unknown-linux-gnu
       - name: Build codegen
         run: |
           cd string-cache-codegen && cargo build && cd ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,23 @@ jobs:
           cargo build --no-default-features
           cargo build
           cargo build --features malloc_size_of
-      - uses: actions-rs/cargo@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --workspace
+      - name: Run Clippy
+        if: ${{ matrix.rust == 'stable' }}
+        run: cargo clippy --workspace
+      - name: Install Miri
+        if: ${{ matrix.rust == 'nightly' }}
+        run: |
+          rustup component add miri
+          cargo miri setup
+      - name: Run Miri
+        if: ${{ matrix.rust == 'nightly' }}
+        # TODO: run without permissive provenance: https://github.com/servo/string-cache/issues/264
+        run: MIRIFLAGS=-Zmiri-permissive-provenance cargo miri test --workspace
       - name: Build codegen
         run: |
           cd string-cache-codegen && cargo build && cd ..
@@ -48,7 +61,6 @@ jobs:
           if [ ${{ matrix.rust }} = nightly ]; then
             cd integration-tests && cargo test --features unstable && cd ..;
           fi
-
 
   build_result:
     name: Result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.85, nightly, beta, stable]
+        rust: [1.85, nightly, stable]
 
     steps:
       - uses: actions/checkout@v2

--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -1,5 +1,3 @@
-use string_cache_codegen;
-
 use std::env;
 use std::path::Path;
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -246,16 +246,21 @@ fn repr() {
     check("xyzzy01", 0x3130_797A_7A79_7871);
 
     // Dynamic atoms. This is a pointer so we can't verify every bit.
-    assert_eq!(0x00, Atom::from("a dynamic string").unsafe_data() & 0xf);
+    let tag_mask = 0b11;
+    let atom = Atom::from("a dynamic string");
+    assert_eq!(0x00, atom.unsafe_data() & tag_mask);
 }
 
 #[test]
 fn test_threads() {
-    for _ in 0_u32..100 {
+    let threads = (0_u32..100).map(|_| {
         thread::spawn(move || {
             let _ = Atom::from("a dynamic string");
             let _ = Atom::from("another string");
-        });
+        })
+    });
+    for thread in threads {
+        thread.join().unwrap();
     }
 }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -161,6 +161,7 @@ fn default() {
 
 #[test]
 fn ord() {
+    #[expect(clippy::cmp_owned)]
     fn check(x: &str, y: &str) {
         assert_eq!(x < y, Atom::from(x) < Atom::from(y));
         assert_eq!(x.cmp(y), Atom::from(x).cmp(&Atom::from(y)));
@@ -363,6 +364,7 @@ fn test_eq_ignore_ascii_case() {
     assert!(!Atom::from("Je vais à Paris").eq_ignore_ascii_case(&Atom::from("JE vais À paris")));
 }
 
+#[expect(clippy::cmp_owned)]
 #[test]
 fn test_from_string() {
     assert!(Atom::from("camembert".to_owned()) == Atom::from("camembert"));

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -64,6 +64,7 @@ fn test_as_bytes() {
 }
 
 #[test]
+#[expect(clippy::comparison_to_empty)]
 fn test_as_ref_str() {
     let s0 = Atom::from("");
     assert!(AsRef::<str>::as_ref(&s0) == "");
@@ -219,8 +220,12 @@ macro_rules! assert_eq_fmt (($fmt:expr, $x:expr, $y:expr) => ({
 
 #[test]
 fn repr() {
-    fn check(s: &str, data: u64) {
-        assert_eq_fmt!("0x{:016X}", Atom::from(s).unsafe_data(), data);
+    #[track_caller]
+    fn check_inline(s: &str, mut expected: u64) {
+        if cfg!(target_endian = "big") {
+            expected = expected.to_le().rotate_left(8)
+        }
+        assert_eq_fmt!("0x{:016X}", Atom::from(s).unsafe_data(), expected);
     }
 
     fn check_static(s: &str, x: Atom) {
@@ -239,12 +244,12 @@ fn repr() {
     check_static("font-weight", test_atom!("font-weight"));
 
     // Inline atoms
-    check("a", 0x0000_0000_0000_6111);
-    check("address", 0x7373_6572_6464_6171);
-    check("area", 0x0000_0061_6572_6141);
-    check("e", 0x0000_0000_0000_6511);
-    check("xyzzy", 0x0000_797A_7A79_7851);
-    check("xyzzy01", 0x3130_797A_7A79_7871);
+    check_inline("a", 0x0000_0000_0000_6111);
+    check_inline("address", 0x7373_6572_6464_6171);
+    check_inline("area", 0x0000_0061_6572_6141);
+    check_inline("e", 0x0000_0000_0000_6511);
+    check_inline("xyzzy", 0x0000_797A_7A79_7851);
+    check_inline("xyzzy01", 0x3130_797A_7A79_7871);
 
     // Dynamic atoms. This is a pointer so we can't verify every bit.
     let tag_mask = 0b11;

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -130,6 +130,11 @@ impl<Static> Atom<Static> {
     fn tag(&self) -> u8 {
         (self.unsafe_data.get() & TAG_MASK) as u8
     }
+
+    /// Assuming DYNAMIC_TAG, return the pointer to `Entry`
+    fn dynamic_ptr(&self) -> *const Entry {
+        std::ptr::with_exposed_provenance(self.unsafe_data.get() as usize)
+    }
 }
 
 impl<Static: StaticAtomSet> Atom<Static> {
@@ -165,7 +170,7 @@ impl<Static: StaticAtomSet> Atom<Static> {
     pub fn get_hash(&self) -> u32 {
         match self.tag() {
             DYNAMIC_TAG => {
-                let entry = self.unsafe_data.get() as *const Entry;
+                let entry = self.dynamic_ptr();
                 unsafe { (*entry).hash }
             }
             STATIC_TAG => Static::get().hashes[self.static_index() as usize],
@@ -243,7 +248,7 @@ impl<'a, Static: StaticAtomSet> From<Cow<'a, str>> for Atom<Static> {
         } else {
             Self::try_static_internal(&*string_to_add).unwrap_or_else(|hash| {
                 let ptr: std::ptr::NonNull<Entry> = dynamic_set().insert(string_to_add, hash.g);
-                let data = ptr.as_ptr() as u64;
+                let data = ptr.as_ptr().expose_provenance() as u64;
                 debug_assert!(0 == data & TAG_MASK);
                 Atom {
                     // The address of a ptr::NonNull is non-zero
@@ -259,7 +264,7 @@ impl<Static: StaticAtomSet> Clone for Atom<Static> {
     #[inline(always)]
     fn clone(&self) -> Self {
         if self.tag() == DYNAMIC_TAG {
-            let entry = self.unsafe_data.get() as *const Entry;
+            let entry = self.dynamic_ptr();
             // SAFETY: `self` is a valid Atom, meaning its `unsafe_data` points to a live `Entry`
             // kept alive by `self`'s reference count. We can safely dereference it.
             if unsafe { &*entry }.ref_count.fetch_add(1, SeqCst) == isize::MAX {
@@ -274,7 +279,7 @@ impl<Static> Drop for Atom<Static> {
     #[inline]
     fn drop(&mut self) {
         if self.tag() == DYNAMIC_TAG {
-            let entry = self.unsafe_data.get() as *const Entry;
+            let entry = self.dynamic_ptr();
             if unsafe { &*entry }.ref_count.fetch_sub(1, SeqCst) == 1 {
                 drop_slow(self)
             }
@@ -282,7 +287,7 @@ impl<Static> Drop for Atom<Static> {
 
         // Out of line to guide inlining.
         fn drop_slow<Static>(this: &mut Atom<Static>) {
-            dynamic_set().remove(this.unsafe_data.get() as *mut Entry);
+            dynamic_set().remove(this.dynamic_ptr().cast_mut());
         }
     }
 }
@@ -295,7 +300,7 @@ impl<Static: StaticAtomSet> ops::Deref for Atom<Static> {
         unsafe {
             match self.tag() {
                 DYNAMIC_TAG => {
-                    let entry = self.unsafe_data.get() as *const Entry;
+                    let entry = self.dynamic_ptr();
                     &(*entry).string
                 }
                 INLINE_TAG => {

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -189,7 +189,7 @@ impl<Static: StaticAtomSet> Atom<Static> {
 
     fn try_static_internal(string_to_add: &str) -> Result<Self, phf_shared::Hashes> {
         let static_set = Static::get();
-        let hash = phf_shared::hash(&*string_to_add, &static_set.key);
+        let hash = phf_shared::hash(string_to_add, &static_set.key);
         let index = phf_shared::get_index(&hash, static_set.disps, static_set.atoms.len());
 
         if static_set.atoms[index as usize] == string_to_add {
@@ -246,7 +246,7 @@ impl<'a, Static: StaticAtomSet> From<Cow<'a, str>> for Atom<Static> {
                 phantom: PhantomData,
             }
         } else {
-            Self::try_static_internal(&*string_to_add).unwrap_or_else(|hash| {
+            Self::try_static_internal(&string_to_add).unwrap_or_else(|hash| {
                 let ptr: std::ptr::NonNull<Entry> = dynamic_set().insert(string_to_add, hash.g);
                 let data = ptr.as_ptr().expose_provenance() as u64;
                 debug_assert!(0 == data & TAG_MASK);
@@ -328,17 +328,14 @@ impl<Static: StaticAtomSet> fmt::Debug for Atom<Static> {
             }
         };
 
-        write!(f, "Atom('{}' type={})", &*self, ty_str)
+        write!(f, "Atom('{}' type={})", self, ty_str)
     }
 }
 
 impl<Static: StaticAtomSet> PartialOrd for Atom<Static> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self.unsafe_data == other.unsafe_data {
-            return Some(Equal);
-        }
-        self.as_str().partial_cmp(other.as_ref())
+        Some(self.cmp(other))
     }
 }
 
@@ -406,14 +403,14 @@ impl<Static: StaticAtomSet> Atom<Static> {
     ///
     /// [`eq_ignore_ascii_case`]: https://doc.rust-lang.org/std/ascii/trait.AsciiExt.html#tymethod.eq_ignore_ascii_case
     pub fn eq_ignore_ascii_case(&self, other: &Self) -> bool {
-        (self == other) || self.eq_str_ignore_ascii_case(&**other)
+        (self == other) || self.eq_str_ignore_ascii_case(other)
     }
 
     /// Like [`eq_ignore_ascii_case`], but takes an unhashed string as `other`.
     ///
     /// [`eq_ignore_ascii_case`]: https://doc.rust-lang.org/std/ascii/trait.AsciiExt.html#tymethod.eq_ignore_ascii_case
     pub fn eq_str_ignore_ascii_case(&self, other: &str) -> bool {
-        (&**self).eq_ignore_ascii_case(other)
+        self.as_str().eq_ignore_ascii_case(other)
     }
 }
 

--- a/src/dynamic_set.rs
+++ b/src/dynamic_set.rs
@@ -9,6 +9,7 @@
 
 use parking_lot::Mutex;
 use std::borrow::Cow;
+use std::cell::UnsafeCell;
 use std::mem;
 use std::ptr::NonNull;
 use std::sync::atomic::AtomicIsize;
@@ -23,10 +24,12 @@ pub(crate) struct Set {
 }
 
 pub(crate) struct Entry {
+    // These fields can be accessed freely by `Atom` methods
     pub(crate) string: Box<str>,
     pub(crate) hash: u32,
     pub(crate) ref_count: AtomicIsize,
-    next_in_bucket: Option<NonNull<Entry>>,
+    // This field is protected by a `Mutex` in `Set`
+    next_in_bucket: UnsafeCell<Option<NonNull<Entry>>>,
 }
 
 // SAFETY: Access to the global linked list is strictly guarded by a Mutex,
@@ -85,13 +88,15 @@ impl Set {
                     entry.ref_count.fetch_sub(1, SeqCst);
                     break;
                 }
-                ptr = entry.next_in_bucket;
+                // SAFETY: We hold the Mutex lock for this bucket, so no other thread can mutate
+                // the linked list.
+                ptr = unsafe { entry.next_in_bucket.get().read() };
             }
         }
         debug_assert!(mem::align_of::<Entry>() >= ENTRY_ALIGNMENT);
         let string = string.into_owned();
         let entry = Box::new(Entry {
-            next_in_bucket: linked_list.take(),
+            next_in_bucket: UnsafeCell::new(linked_list.take()),
             hash,
             ref_count: AtomicIsize::new(1),
             string: string.into_boxed_str(),
@@ -118,12 +123,15 @@ impl Set {
             if entry_ptr.as_ptr() == ptr {
                 // SAFETY: The reference count has reached 0, and we hold the bucket lock.
                 // We have exclusive access to recreate the Box and deallocate the memory.
-                let mut unlinked_entry = unsafe { Box::from_raw(entry_ptr.as_ptr()) };
-                *current = unlinked_entry.next_in_bucket.take();
+                let unlinked_entry = unsafe { Box::from_raw(entry_ptr.as_ptr()) };
+                *current = unlinked_entry.next_in_bucket.into_inner();
                 break;
             }
             // SAFETY: We hold the bucket lock, so the pointer remains valid and unaliased here.
-            current = unsafe { &mut (*entry_ptr.as_ptr()).next_in_bucket };
+            // Still, don’t create `&mut Entry` here because `Atom` methods may have a `&Entry`.
+            let entry = unsafe { entry_ptr.as_ref() };
+            // SAFETY: The `UnsafeCell` is safe to access here because we hold the `Mutex`
+            current = unsafe { &mut *entry.next_in_bucket.get() };
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,19 +103,6 @@
 
 #![cfg_attr(test, deny(warnings))]
 
-// Types, such as Atom, that impl Hash must follow the hash invariant: if two objects match
-// with PartialEq, they must also have the same Hash. Clippy warns on types that derive one while
-// manually impl-ing the other, because it seems easy for the two to drift apart, causing the
-// invariant to be violated.
-//
-// But Atom is a newtype over NonZeroU64, and probably always will be, since cheap comparisons and
-// copying are this library's purpose. So we know what the PartialEq comparison is going to do.
-//
-// The `get_hash` function, seen in `atom.rs`, consults that number, plus the global string interner
-// tables. The only way for the resulting hash for two Atoms with the same inner 64-bit number to
-// differ would be if the table entry changed between invocations, and that would be really bad.
-#![allow(clippy::derive_hash_xor_eq)]
-
 mod atom;
 mod dynamic_set;
 mod static_sets;

--- a/src/trivial_impls.rs
+++ b/src/trivial_impls.rs
@@ -43,7 +43,7 @@ impl<Static: StaticAtomSet> PartialEq<String> for Atom<Static> {
     }
 }
 
-impl<'a, Static: StaticAtomSet> From<&'a str> for Atom<Static> {
+impl<Static: StaticAtomSet> From<&'_ str> for Atom<Static> {
     #[inline]
     fn from(string_to_add: &str) -> Self {
         Atom::from(Cow::Borrowed(string_to_add))

--- a/string-cache-codegen/lib.rs
+++ b/string-cache-codegen/lib.rs
@@ -201,6 +201,7 @@ impl AtomType {
         Ok(str)
     }
 
+    #[expect(clippy::wrong_self_convention)] // Doesn’t matter on a private method
     fn to_tokens(&mut self) -> proc_macro2::TokenStream {
         // `impl Default for Atom` requires the empty string to be in the static set.
         // This also makes sure the set in non-empty,
@@ -259,7 +260,7 @@ impl AtomType {
         let type_name = path_parts.next().unwrap();
         let module = match path_parts.next() {
             Some(m) => format!("$crate::{}", m),
-            None => format!("$crate"),
+            None => "$crate".to_string(),
         };
         let atom_doc = match self.atom_doc {
             Some(ref doc) => quote!(#[doc = #doc]),
@@ -278,7 +279,7 @@ impl AtomType {
         }
         let static_set_name = new_term(&format!("{}StaticSet", type_name));
         let type_name = new_term(type_name);
-        let macro_name = new_term(&*self.macro_name);
+        let macro_name = new_term(&self.macro_name);
         let module = module.parse::<proc_macro2::TokenStream>().unwrap();
         let atom_prefix = format!("ATOM_{}_", type_name.to_string().to_uppercase());
         let new_const_name = |atom: &str| {
@@ -308,7 +309,7 @@ impl AtomType {
 
                 let mut value = 0u64;
                 for (index, c) in s.bytes().enumerate() {
-                    value = value | ((c as u64) << (index * 8 + 8));
+                    value |= (c as u64) << (index * 8 + 8);
                 }
 
                 let len = s.len() as u8;


### PR DESCRIPTION
Also remove CI with Rust beta toolchain. It consumes resources without bringing much, when we also have stable and nightly

Fixes #264
Fixes #216
Fixes #217: CI now runs Miri with big-endian `s390x-unknown-linux-gnu`
Fixes #162: CI now runs Miri with 32-bit `i686-unknown-linux-gnu`
Fixes #33: I’ve manually run each of the test executables in Valgrind, it shows zero error now
Closes https://github.com/servo/string-cache/issues/32: not literally done but Miri achieves the same