### PR TITLE
Try the ptrhash feature from phf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default = ["serde_support"]
 precomputed-hash = "0.1"
 serde = { version = "1", optional = true }
 malloc_size_of = { version = "0.1", default-features = false, optional = true }
-phf_shared = "0.14"
+phf_shared = { version = "0.14", features = ["ptrhash"] }
 new_debug_unreachable = "1.0.2"
 parking_lot = "0.12"
 

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -214,10 +214,16 @@ impl<Static: StaticAtomSet> Atom<Static> {
         Self::try_static_internal(string_to_add).ok()
     }
 
-    fn try_static_internal(string_to_add: &str) -> Result<Self, phf_shared::Hashes> {
+    fn try_static_internal(string_to_add: &str) -> Result<Self, u64> {
         let static_set = Static::get();
-        let hash = phf_shared::hash(string_to_add, &static_set.key);
-        let index = phf_shared::get_index(&hash, static_set.disps, static_set.atoms.len());
+        let hash = phf_shared::ptrhash::hash(string_to_add, &static_set.seed);
+        let index = phf_shared::ptrhash::get_index(
+            static_set.seed,
+            hash,
+            static_set.pilots,
+            static_set.remap,
+            static_set.atoms.len(),
+        );
 
         if static_set.atoms[index as usize] == string_to_add {
             Ok(Self::pack_static(index))
@@ -272,9 +278,6 @@ impl<'a, Static: StaticAtomSet> From<Cow<'a, str>> for Atom<Static> {
             }
         } else {
             Self::try_static_internal(&string_to_add).unwrap_or_else(|hash| {
-                // Reconstitute 64-bit `Hash128::h1`
-                // https://docs.rs/phf_shared/0.14.0/src/phf_shared/lib.rs.html#45-54
-                let hash = (hash.g as u64) << 32 | (hash.f1 as u64);
                 let ptr: std::ptr::NonNull<Entry> = dynamic_set().insert(string_to_add, hash);
                 let data = ptr.as_ptr().expose_provenance() as u64;
                 debug_assert!(0 == data & TAG_MASK);

--- a/src/static_sets.rs
+++ b/src/static_sets.rs
@@ -29,9 +29,11 @@ pub trait StaticAtomSet: Ord {
 /// [Hash, Displace and Compress]: http://cmph.sourceforge.net/papers/esa09.pdf
 pub struct PhfStrSet {
     #[doc(hidden)]
-    pub key: u64,
+    pub seed: u64,
     #[doc(hidden)]
-    pub disps: &'static [(u32, u32)],
+    pub pilots: &'static [u8],
+    #[doc(hidden)]
+    pub remap: &'static [u32],
     #[doc(hidden)]
     pub atoms: &'static [&'static str],
     #[doc(hidden)]
@@ -47,8 +49,9 @@ impl StaticAtomSet for EmptyStaticAtomSet {
         // The name is a lie: this set is not empty (it contains the empty string)
         // but that’s only to avoid divisions by zero in rust-phf.
         static SET: PhfStrSet = PhfStrSet {
-            key: 0,
-            disps: &[(0, 0)],
+            seed: 0,
+            pilots: &[0],
+            remap: &[0],
             atoms: &[""],
             // "" SipHash'd, and xored with u64_hash_to_u32.
             hashes: &[0x3ddddef3],

--- a/string-cache-codegen/Cargo.toml
+++ b/string-cache-codegen/Cargo.toml
@@ -13,7 +13,7 @@ name = "string_cache_codegen"
 path = "lib.rs"
 
 [dependencies]
-phf_generator = "0.14"
-phf_shared = "0.14"
+phf_generator = { version = "0.14", features = ["ptrhash"] }
+phf_shared = { version = "0.14", features = ["ptrhash"] }
 proc-macro2 = "1"
 quote = "1"

--- a/string-cache-codegen/lib.rs
+++ b/string-cache-codegen/lib.rs
@@ -220,9 +220,13 @@ impl AtomType {
         }
 
         // Static strings
-        let hash_state = phf_generator::generate_hash(&static_strs);
-        let phf_generator::HashState { key, disps, map } = hash_state;
-        let (disps0, disps1): (Vec<_>, Vec<_>) = disps.into_iter().unzip();
+        let hash_state = phf_generator::ptrhash::generate_hash(&static_strs);
+        let phf_generator::ptrhash::HashState {
+            seed,
+            pilots,
+            remap,
+            map,
+        } = hash_state;
         let atoms: Vec<&str> = map.iter().map(|&idx| static_strs[idx]).collect();
         let indices = 0..atoms.len() as u32;
 
@@ -252,12 +256,7 @@ impl AtomType {
 
         let hashes: Vec<u64> = atoms
             .iter()
-            .map(|string| {
-                let hash = phf_shared::hash(string, &key);
-                // Reconstitute 64-bit `Hash128::h1`
-                // https://docs.rs/phf_shared/0.14.0/src/phf_shared/lib.rs.html#45-54
-                (hash.g as u64) << 32 | (hash.f1 as u64)
-            })
+            .map(|string| phf_shared::ptrhash::hash(string, &seed))
             .collect();
 
         let mut path_parts = self.path.rsplitn(2, "::");
@@ -335,8 +334,9 @@ impl AtomType {
             impl ::string_cache::StaticAtomSet for #static_set_name {
                 fn get() -> &'static ::string_cache::PhfStrSet {
                     static SET: ::string_cache::PhfStrSet = ::string_cache::PhfStrSet {
-                        key: #key,
-                        disps: &[#((#disps0, #disps1)),*],
+                        seed: #seed,
+                        pilots: &[#(#pilots),*],
+                        remap: &[#(#remap),*],
                         atoms: &[#(#atoms),*],
                         hashes: &[#(#hashes),*]
                     };


### PR DESCRIPTION
See https://github.com/rust-phf/rust-phf/pull/392 and https://github.com/rust-phf/rust-phf/issues/349

Fixes https://github.com/servo/string-cache/issues/31

~~This goes on top of https://github.com/servo/string-cache/pull/306~~

To run benchmarks:

* Switch to https://github.com/servo/string-cache/pull/306
* Run `cargo bench --workspace --bench micro -- 'atom.*(as_str|intern)'` to save a baseline
* Switch to this PR
* Run the same `cargo bench --workspace --bench micro -- 'atom.*(as_str|intern)'` command again, Criterion defaults to treating the previous run as a baseline to compare against.

The results on my desktop machine are mixed, I’m not sure what to make of them:

```
static_atom intern      time:   [18.177 ns 18.283 ns 18.399 ns]
                        change: [−26.752% −26.353% −25.942%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

static_atom as_str ×1000
                        time:   [488.64 ns 495.40 ns 501.82 ns]
                        change: [+11.981% +14.462% +16.911%] (p = 0.00 < 0.05)
                        Performance has regressed.

short_inline_atom intern
                        time:   [8.2140 ns 8.2437 ns 8.2728 ns]
                        change: [−0.9334% −0.2491% +0.3623%] (p = 0.47 > 0.05)
                        No change in performance detected.

short_inline_atom as_str ×1000
                        time:   [468.30 ns 469.63 ns 471.06 ns]
                        change: [−0.7047% −0.1391% +0.4225%] (p = 0.63 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

medium_inline_atom intern
                        time:   [8.4393 ns 8.4672 ns 8.4977 ns]
                        change: [+0.1231% +0.6802% +1.2484%] (p = 0.02 < 0.05)
                        Change within noise threshold.

medium_inline_atom as_str ×1000
                        time:   [468.63 ns 470.26 ns 471.94 ns]
                        change: [−0.7374% −0.1749% +0.3837%] (p = 0.55 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

min_dynamic_atom intern time:   [60.353 ns 60.624 ns 60.895 ns]
                        change: [−10.002% −8.5817% −7.5724%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

min_dynamic_atom as_str ×1000
                        time:   [275.20 ns 299.50 ns 326.12 ns]
                        change: [+0.3170% +10.220% +20.425%] (p = 0.04 < 0.05)
                        Change within noise threshold.

longer_dynamic_atom intern
                        time:   [100.59 ns 100.99 ns 101.40 ns]
                        change: [+32.264% +33.042% +33.859%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

longer_dynamic_atom as_str ×1000
                        time:   [274.90 ns 299.56 ns 326.75 ns]
                        change: [+0.5408% +10.256% +20.929%] (p = 0.04 < 0.05)
                        Change within noise threshold.
```