### PR TITLE
Fix compiling benchmarks on 1.85

### DIFF
--- a/integration-tests/benches/micro.rs
+++ b/integration-tests/benches/micro.rs
@@ -188,7 +188,7 @@ fn bench_rand<const LEN: usize>(bencher: &mut criterion::Bencher) {
             // shift into printable ASCII
             *n = (*n % 0x40) + 0x20;
         }
-        let s = str::from_utf8(&buf[..]).unwrap();
+        let s = std::str::from_utf8(&buf[..]).unwrap();
         black_box(TestAtom::from(s));
     })
 }


### PR DESCRIPTION
Somehow https://github.com/servo/string-cache/pull/306 was merged despite a failing CI job